### PR TITLE
Migrate CI to SciML centralized reusable workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,24 @@
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "julia"
+    directories:
+      - "/"
+      - "/CanonicalMoments.jl"
+      - "/CanonicalMoments.jl/docs"
+      - "/CanonicalMoments.jl/examples"
+      - "/CanonicalMoments.jl/test"
+      - "/DiscreteMeasures.jl"
+      - "/DiscreteMeasures.jl/docs"
+      - "/OUQBase.jl"
+      - "/OUQBase.jl/test"
+    schedule:
+      interval: "daily"
+    groups:
+      all-julia-packages:
+        patterns:
+          - "*"

--- a/.github/workflows/FormatCheck.yml
+++ b/.github/workflows/FormatCheck.yml
@@ -1,0 +1,17 @@
+name: "Format Check"
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  format-check:
+    name: "Runic Format Check"
+    uses: "SciML/.github/.github/workflows/runic.yml@v1"
+    secrets: "inherit"

--- a/.github/workflows/SpellCheck.yml
+++ b/.github/workflows/SpellCheck.yml
@@ -1,0 +1,17 @@
+name: "Spell Check"
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  spell-check:
+    name: "Spell Check with Typos"
+    uses: "SciML/.github/.github/workflows/spellcheck.yml@v1"
+    secrets: "inherit"

--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -19,37 +19,21 @@ concurrency:
 jobs:
   test:
     name: "Test ${{ matrix.submodule }} on Julia ${{ matrix.version }}"
-    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
         submodule:
-          - CanonicalMoments
-          - DiscreteMeasures
-          - OUQBase
+          - CanonicalMoments.jl
+          - DiscreteMeasures.jl
+          - OUQBase.jl
         version:
           - '1.12'
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-
-      - name: "Setup Julia ${{ matrix.version }}"
-        uses: julia-actions/setup-julia@v2
-        with:
-          version: "${{ matrix.version }}"
-      
-      - name: Cache Julia artifacts
-        uses: julia-actions/cache@v1
-        with:
-          token: "${{ secrets.GITHUB_TOKEN }}"
-
-      - name: "Instantiate workspace and run tests for ${{ matrix.submodule }}"
-        run: |
-          julia --project=. -e '
-            using Pkg
-            Pkg.instantiate()
-            Pkg.test("${{ matrix.submodule }}")
-          '
+    uses: "SciML/.github/.github/workflows/tests.yml@v1"
+    with:
+      julia-version: "${{ matrix.version }}"
+      project: "${{ matrix.submodule }}"
+      coverage: false
+    secrets: "inherit"
 
   upload-manifest:
     name: "Upload Manifest"

--- a/CanonicalMoments.jl/docs/make.jl
+++ b/CanonicalMoments.jl/docs/make.jl
@@ -12,7 +12,7 @@ makedocs(;
     modules = [CanonicalMoments],
     authors = "TODO",
     sitename = "CanonicalMoments.jl",
-    format = Documenter.HTML(;),
+    format = Documenter.HTML(),
     pages = ["Home" => "index.md"],
 )
 #=

--- a/CanonicalMoments.jl/examples/1_Stenger_flood.jl
+++ b/CanonicalMoments.jl/examples/1_Stenger_flood.jl
@@ -27,19 +27,19 @@ c1 = [
 c2 = [
     [1320.42, 2.1632e6], # means and 2nd moments
     [30.0, 949.137],
-    [50.0, 7501/3.0],
-    [54.5, 8911/3.0],
+    [50.0, 7501 / 3.0],
+    [54.5, 8911 / 3.0],
 ]
 
 c3 = [
     [1320.42, 2.1632e6, 4.18e9], # means and 3rd moments
     [30.0, 949.137, 31422.3],
-    [50.0, 7501/3.0, 125050.0],
-    [54.5, 8911/3.0, 647569/4.0],
+    [50.0, 7501 / 3.0, 125050.0],
+    [54.5, 8911 / 3.0, 647569 / 4.0],
 ]
 
-p1_free = [rand(2) for i = 1:4]
-p2_free = [rand(3) for i = 1:4]
+p1_free = [rand(2) for i in 1:4]
+p2_free = [rand(3) for i in 1:4]
 
 pof_ = pof(ql, qu, c1, g_h(2), p1_free)
 pof2_ = pof(ql, qu, c2, g_h(2), p2_free)
@@ -47,15 +47,15 @@ pof2_ = pof(ql, qu, c2, g_h(2), p2_free)
 ## Compare to Stenger
 ### 1 Moment Contstraint
 threshold = 4
-p1_free = [fill(0.5, 2) for i = 1:4]
+p1_free = [fill(0.5, 2) for i in 1:4]
 pof_ = pof(ql, qu, c1, g_h(threshold), p1_free)
 @assert pof_ ≈ 0.8346769701
 
-p1_free = [fill(0.25, 2) for i = 1:4]
+p1_free = [fill(0.25, 2) for i in 1:4]
 pof_ = pof(ql, qu, c1, g_h(threshold), p1_free)
 @assert pof_ ≈ 0.8423597615
 
-p1_free = [fill(0.75, 2) for i = 1:4]
+p1_free = [fill(0.75, 2) for i in 1:4]
 pof_ = pof(ql, qu, c1, g_h(threshold), p1_free)
 @assert pof_ ≈ 0.8355977711
 
@@ -69,15 +69,15 @@ pof_ = pof(ql, qu, c1, g_h(threshold), p1_free)
 @assert pof_ ≈ 0.8877773081
 
 ### 2 Moment Constraints
-p2_free = [fill(0.5, 3) for i = 1:4]
+p2_free = [fill(0.5, 3) for i in 1:4]
 pof_ = pof(ql, qu, c2, g_h(threshold), p2_free)
 @assert pof_ ≈ 0.9084523325
 
-p2_free = [fill(0.25, 3) for i = 1:4]
+p2_free = [fill(0.25, 3) for i in 1:4]
 pof_ = pof(ql, qu, c2, g_h(threshold), p2_free)
 @assert pof_ ≈ 0.9158574604
 
-p2_free = [fill(0.75, 3) for i = 1:4]
+p2_free = [fill(0.75, 3) for i in 1:4]
 pof_ = pof(ql, qu, c2, g_h(threshold), p2_free)
 @assert pof_ ≈ 0.9429896112
 
@@ -91,15 +91,15 @@ pof_ = pof(ql, qu, c2, g_h(threshold), p2_free)
 @assert pof_ ≈ 0.9018177916
 
 ### 3 Moment Constraints
-p3_free = [fill(0.5, 4) for i = 1:4]
+p3_free = [fill(0.5, 4) for i in 1:4]
 pof_ = pof(ql, qu, c3, g_h(threshold), p3_free)
-@assert pof_ ≈ 0.9385050420
+@assert pof_ ≈ 0.938505042
 
-p3_free = [fill(0.25, 4) for i = 1:4]
+p3_free = [fill(0.25, 4) for i in 1:4]
 pof_ = pof(ql, qu, c3, g_h(threshold), p3_free)
 @assert pof_ ≈ 0.9267572769
 
-p3_free = [fill(0.75, 4) for i = 1:4]
+p3_free = [fill(0.75, 4) for i in 1:4]
 pof_ = pof(ql, qu, c3, g_h(threshold), p3_free)
 @assert pof_ ≈ 0.9327169677
 

--- a/CanonicalMoments.jl/examples/experiments_obe.jl
+++ b/CanonicalMoments.jl/examples/experiments_obe.jl
@@ -1,8 +1,7 @@
-
 #######################################
 
 # support_alg = PolyRootsSupportAlg(quadratic_eq_sridhare)
-# function solver(A, b) 
+# function solver(A, b)
 #     display(A)
 #     display(b)
 #     IntervalLinearAlgebra.solve(A, b, Jacobi(), NoPrecondition(), fill(0..1, n+1))
@@ -25,7 +24,7 @@ support_points, weights = transform(p_free; support_alg, weight_alg)
 support_points = support_points .∩ Interval(lb, ub)
 
 for pt in support_points
-    band!([inf(pt), sup(pt)], fill(-0.2, n+1), fill(0.2, n+1))
+    band!([inf(pt), sup(pt)], fill(-0.2, n + 1), fill(0.2, n + 1))
 end
 
 raw_reconstructed2 = map(1:n) do i
@@ -43,8 +42,6 @@ raw_constraints .∈ raw_reconstructed2
 CanonicalMoments2.expectation(sin, support_points, weights)
 
 
-
-
 # Reconstruct raw moments from discrete measure and compare to verify raw constraints are met
 x, weights = transform(sol; support_alg, weight_alg)
 weights
@@ -59,7 +56,7 @@ raw_constraints ≈ raw_reconstructed
 using GLMakie
 
 xs = map(1:100000) do i
-    p_free = rand(n+1)
+    p_free = rand(n + 1)
     support_points, weights = transform(p_free; support_alg, weight_alg)
     support_points
 end
@@ -70,15 +67,15 @@ hist(xsv; normalization = :pdf, bins = 100)
 
 
 f = hist(getindex.(xs, 1); normalization = :probability, bins = 100)
-for i = 2:(n+1)
+for i in 2:(n + 1)
     hist!(getindex.(xs, i); normalization = :probability, bins = 100)
 end
 f
 
 cms = transform.cm_seq
 
-pfrees = [rand(n+1) for _ = 1:1000]
-SRs = map(p->StieltjesTransform(cms, p), pfrees)
+pfrees = [rand(n + 1) for _ in 1:1000]
+SRs = map(p -> StieltjesTransform(cms, p), pfrees)
 Bs = getfield.(SRs, :B)
 Cs = getfield.(SRs, :C)
 
@@ -91,10 +88,10 @@ npolys = map(SRs) do SR
 end
 
 begin
-    f = lines(0..1, npolys[1]//polys[1])
+    f = lines(0 .. 1, npolys[1] // polys[1])
 
     for (p, n) in zip(polys, npolys)
-        lines!(0..1, n/p, color = (:red, 0.008))
+        lines!(0 .. 1, n / p, color = (:red, 0.008))
     end
 end
 

--- a/CanonicalMoments.jl/examples/multivariate_example.jl
+++ b/CanonicalMoments.jl/examples/multivariate_example.jl
@@ -17,8 +17,8 @@ ub = [3580.0, 47.45, 51.0, 55.0]  # upper bounds on random variables
 raws = [
     [1320.42, 2.1632e6, 4.18e9], # Q, 1,2, 3 raw moments
     [30.0, 949.137, 31422.3], #Ks
-    [50.0, 7501/3.0, 125050.0], #Zv
-    [54.5, 8911/3.0, 647569/4.0], #Zm
+    [50.0, 7501 / 3.0, 125050.0], #Zv
+    [54.5, 8911 / 3.0, 647569 / 4.0], #Zm
 ]
 
 raw_seqences = RawMomentSequence.(raws, lb, ub)
@@ -38,7 +38,7 @@ joint_μ = ProductDiscreteMeasure(independent_μs)
 # check raw moments match constraints
 map(enumerate(raws)) do (i, rawsi)
     map(enumerate(rawsi)) do (k, c)
-        expectation(x->x[i]^k, joint_μ) ≈ c
+        expectation(x -> x[i]^k, joint_μ) ≈ c
     end |> all
 end |> all
 
@@ -54,20 +54,20 @@ function objective(x, params)
     independent_μs = map(enumerate(params.transforms)) do (i, t)
         p_free = eltype(x)[]
 
-        for _ = 1:nvars[i]
+        for _ in 1:nvars[i]
             push!(p_free, popfirst!(_x))
         end
         t(p_free; support_alg, weight_alg)
     end
     μ = ProductDiscreteMeasure(independent_μs)
-    expectation(H, μ)
+    return expectation(H, μ)
 end
 
 F = OptimizationFunction(objective, Optimization.AutoForwardDiff())
 
 nvars_part = length.(raws) .+ 1
 nvars = sum(nvars_part)
-u0 = fill(1/2, nvars)
+u0 = fill(1 / 2, nvars)
 params = (; transforms, support_alg, weight_alg, nvars_part)
 prob = OptimizationProblem(F, u0, params, lb = zeros(nvars), ub = ones(nvars))
 @time sol = solve(prob, NelderMead())
@@ -78,7 +78,7 @@ _x = copy(sol.u)
 independent_μs = map(enumerate(params.transforms)) do (i, t)
     p_free = eltype(_x)[]
 
-    for _ = 1:nvars_part[i]
+    for _ in 1:nvars_part[i]
         push!(p_free, popfirst!(_x))
     end
     t(p_free; support_alg, weight_alg)

--- a/CanonicalMoments.jl/examples/univariate_example.jl
+++ b/CanonicalMoments.jl/examples/univariate_example.jl
@@ -6,8 +6,8 @@ using CanonicalMoments,
     ForwardDiff, Polynomials, IntervalArithmetic, Optimization, OptimizationOptimJL
 # using IntervalLinearAlgebra
 
-# generate example data. first n raw moments of uniform distribution that would define the admissible set. 
-uniform_raw_moment(a, b, n) = (b^(n+1) - a^(n+1)) / ((n+1)*(b-a))
+# generate example data. first n raw moments of uniform distribution that would define the admissible set.
+uniform_raw_moment(a, b, n) = (b^(n + 1) - a^(n + 1)) / ((n + 1) * (b - a))
 
 lb = 0
 ub = 2
@@ -20,7 +20,7 @@ rms = RawMomentSequence(raw_constraints, lb, ub)
 transform = DiscreteMeasureTransform1(rms)   # callable struct
 
 # Given n raw constraints, pick n+1 free parameters, this is what we optimize over
-p_free = fill(1/2, n+1)
+p_free = fill(1 / 2, n + 1)
 
 support_alg = EigvalSupportAlg()
 weight_alg = PolyWeightAlg()
@@ -35,7 +35,7 @@ sum(weights(μ)) ≈ 1
 
 # Check raw moments match constraints
 map(enumerate(raw_constraints)) do (i, c)
-    expectation(x->x^i, μ) ≈ c
+    expectation(x -> x^i, μ) ≈ c
 end |> all
 
 # Optimization
@@ -47,14 +47,14 @@ function objective(x, params)
         support_alg = params.support_alg,
         weight_alg = params.weight_alg,
     )
-    expectation(g, μ)
+    return expectation(g, μ)
 end
 
 F = OptimizationFunction(objective, Optimization.AutoForwardDiff())
 
-u0 = fill(1/2, n+1)
+u0 = fill(1 / 2, n + 1)
 params = (; transform, support_alg, weight_alg)
-prob = OptimizationProblem(F, u0, params, lb = zeros(n+1), ub = ones(n+1))
+prob = OptimizationProblem(F, u0, params, lb = zeros(n + 1), ub = ones(n + 1))
 sol = solve(prob, NelderMead())
 sol.objective
 μ_opt = transform(sol.u)

--- a/CanonicalMoments.jl/examples/univariate_intervals_example.jl
+++ b/CanonicalMoments.jl/examples/univariate_intervals_example.jl
@@ -6,8 +6,8 @@ using CanonicalMoments,
     ForwardDiff, Polynomials, IntervalArithmetic, Optimization, OptimizationOptimJL
 using IntervalLinearAlgebra, IntervalEigenSolvers, DiscreteMeasures
 
-# generate example data. first n raw moments of uniform distribution that would define the admissible set. 
-uniform_raw_moment(a, b, n) = (b^(n+1) - a^(n+1)) / ((n+1)*(b-a))
+# generate example data. first n raw moments of uniform distribution that would define the admissible set.
+uniform_raw_moment(a, b, n) = (b^(n + 1) - a^(n + 1)) / ((n + 1) * (b - a))
 
 lb = 0
 ub = 2
@@ -20,7 +20,7 @@ rms = RawMomentSequence(raw_constraints, lb, ub)
 transform = DiscreteMeasureTransform1(rms)   # callable struct
 
 # Given n raw constraints, pick n+1 free parameters, this is what we optimize over
-p_free = fill(Interval(0.5, 0.6), n+1)
+p_free = fill(Interval(0.5, 0.6), n + 1)
 
 support_alg = EigvalSupportAlg()
 weight_alg = EigvecWeightAlg()
@@ -32,7 +32,7 @@ weight_alg = EigvecWeightAlg()
 
 # Check raw moments contained in intervals
 map(enumerate(raw_constraints)) do (i, c)
-    c ∈ expectation(x->x^i, μ_tight)
+    c ∈ expectation(x -> x^i, μ_tight)
 end |> all
 
 g(x) = sin(x)
@@ -49,7 +49,7 @@ range_g = g(_x)
 w = weights(μ_tight)
 
 function clamp_sum(w)
-    map(1:length(w)) do i
+    return map(1:length(w)) do i
         @views 1 - sum(w[1:length(w) .!= i])
     end
 end
@@ -63,8 +63,8 @@ A = CanonicalMoments._companion_matrix(ST)
 
 # Gerlach worst/case 1st eigenvector element
 function clamp_gerlach(A, λ)
-    map(1:length(λ)) do i
-        Interval(0, sup(1/(((λ[i] - A[1, 1])/A[1, 2])^2 + 1)))
+    return map(1:length(λ)) do i
+        Interval(0, sup(1 / (((λ[i] - A[1, 1]) / A[1, 2])^2 + 1)))
     end
 end
 
@@ -72,8 +72,6 @@ w = weights(μ)
 wn = normalize(w)
 wn2 = IntervalEigenSolvers.normalize2(A, λ, 1)
 b = clamp_gerlach(A, λ)
-
-
 
 
 μ_tight2 = DiscreteMeasure(support(μ_tight), intersect.(w, b, a))

--- a/CanonicalMoments.jl/ext/ChainRulesCoreExt.jl
+++ b/CanonicalMoments.jl/ext/ChainRulesCoreExt.jl
@@ -4,5 +4,4 @@ using ChainRulesCore
 import CanonicalMoments: simple_real_roots, DEFAULT_ROOT_SOLVER
 
 
-
 end

--- a/CanonicalMoments.jl/ext/ForwardDiffExt.jl
+++ b/CanonicalMoments.jl/ext/ForwardDiffExt.jl
@@ -4,11 +4,11 @@ using ForwardDiff, Polynomials
 import CanonicalMoments: simple_real_roots, DEFAULT_ROOT_SOLVER
 
 function simple_real_roots(
-    P::AbstractPolynomial{𝕋},
-    root_solver,
-    args...;
-    kwargs...,
-) where {𝕋<:ForwardDiff.Dual}
+        P::AbstractPolynomial{𝕋},
+        root_solver,
+        args...;
+        kwargs...,
+    ) where {𝕋 <: ForwardDiff.Dual}
     C = ForwardDiff.value.(coeffs(P))
     ∂C = ForwardDiff.partials.(coeffs(P))
 
@@ -17,8 +17,8 @@ function simple_real_roots(
     denomenator = Polynomials.derivative(P)
 
     X = root_solver(P)
-    map(X) do xi
-        𝕋(xi, numerator(xi)/denomenator(xi))
+    return map(X) do xi
+        𝕋(xi, numerator(xi) / denomenator(xi))
     end
 end
 

--- a/CanonicalMoments.jl/ext/SymbolicsExt.jl
+++ b/CanonicalMoments.jl/ext/SymbolicsExt.jl
@@ -25,7 +25,7 @@ end
 function CanonicalMoments._companion_matrix(B::Vector{Num}, C::Vector{Num})
     dv = -B
     ndims = length(B)
-    ev = sqrt.(C[2:end]) # Probably use views here 
+    ev = sqrt.(C[2:end]) # Probably use views here
     _comp_mat_unwrapped = array_term(
         SymTridiagonal,
         unwrap.(dv),
@@ -33,7 +33,7 @@ function CanonicalMoments._companion_matrix(B::Vector{Num}, C::Vector{Num})
         eltype = Real,
         size = (ndims, ndims),
     )
-    wrap(_comp_mat_unwrapped)
+    return wrap(_comp_mat_unwrapped)
 end
 
 end

--- a/CanonicalMoments.jl/src/CanonicalMoments.jl
+++ b/CanonicalMoments.jl/src/CanonicalMoments.jl
@@ -11,7 +11,7 @@ import DiscreteMeasures: support, weights
 import Polynomials: denominator, numerator
 
 function DEFAULT_ROOT_SOLVER(C, args...; kwargs...)
-    if length(C) == 3      # 2nd order
+    return if length(C) == 3      # 2nd order
         quadratic_eq_sridhare(C, args...; kwargs...)
     elseif length(C) == 4  # 3rd order
         simple_real_cubic_eq(C, args...; kwargs...)

--- a/CanonicalMoments.jl/src/measure_transform_algs.jl
+++ b/CanonicalMoments.jl/src/measure_transform_algs.jl
@@ -23,12 +23,12 @@ Note, that the polynomial is guaranteed to have real, unique roots.
 - `args`: Additional arguments passed to the `solver`.
 - `kwargs`: Additional keyword arguments passed to the `solver`.
 """
-struct PolyRootsSupportAlg{𝕊,𝔸,𝕂} <: AbstractSupportAlg
+struct PolyRootsSupportAlg{𝕊, 𝔸, 𝕂} <: AbstractSupportAlg
     solver::𝕊
     args::𝔸
     kwargs::𝕂
     PolyRootsSupportAlg(alg = DEFAULT_ROOT_SOLVER, args...; kwargs...) =
-        new{typeof(alg),typeof(args),typeof(kwargs)}(alg, args, kwargs)
+        new{typeof(alg), typeof(args), typeof(kwargs)}(alg, args, kwargs)
 end
 
 """
@@ -43,12 +43,12 @@ The default solver is set to `DEFAULT_EIGENVAL_SOLVER`.
 - `args`: Additional arguments passed to the `solver`.
 - `kwargs`: Additional keyword arguments passed to the `solver`.
 """
-struct EigvalSupportAlg{𝕊,𝔸,𝕂} <: AbstractSupportAlg
+struct EigvalSupportAlg{𝕊, 𝔸, 𝕂} <: AbstractSupportAlg
     solver::𝕊
     args::𝔸
     kwargs::𝕂
     EigvalSupportAlg(alg = DEFAULT_EIGENVAL_SOLVER, args...; kwargs...) =
-        new{typeof(alg),typeof(args),typeof(kwargs)}(alg, args, kwargs)
+        new{typeof(alg), typeof(args), typeof(kwargs)}(alg, args, kwargs)
 end
 (alg::EigvalSupportAlg)(M::AbstractMatrix{<:Real}) =
     collect(alg.solver(M, alg.args...; alg.kwargs...))
@@ -73,12 +73,12 @@ Computes the weights of a discrete measure by solving a linear system. The defau
 - `args`: Additional positional arguments passed to the `solver`.
 - `kwargs`: Additional keyword arguments passed to the `solver`.
 """
-struct LinearSolveWeightAlg{𝕊,𝔸,𝕂} <: AbstractWeightAlg
+struct LinearSolveWeightAlg{𝕊, 𝔸, 𝕂} <: AbstractWeightAlg
     solver::𝕊
     args::𝔸
     kwargs::𝕂
     LinearSolveWeightAlg(alg = DEFAULT_LINEARSOLVE_SOLVER, args...; kwargs...) =
-        new{typeof(alg),typeof(args),typeof(kwargs)}(alg, args, kwargs)
+        new{typeof(alg), typeof(args), typeof(kwargs)}(alg, args, kwargs)
 end
 
 """
@@ -104,12 +104,12 @@ The default solver is set to `DEFAULT_EIGENVEC_SOLVER`.
 - `args`: Additional arguments passed to the `solver`.
 - `kwargs`: Additional keyword arguments passed to the `solver`.
 """
-struct EigvecWeightAlg{𝕊,𝔸,𝕂} <: AbstractWeightAlg
+struct EigvecWeightAlg{𝕊, 𝔸, 𝕂} <: AbstractWeightAlg
     solver::𝕊
     args::𝔸
     kwargs::𝕂
     EigvecWeightAlg(alg = DEFAULT_EIGENVEC_SOLVER, args...; kwargs...) =
-        new{typeof(alg),typeof(args),typeof(kwargs)}(alg, args, kwargs)
+        new{typeof(alg), typeof(args), typeof(kwargs)}(alg, args, kwargs)
 end
 
 (alg::EigvecWeightAlg)(M::AbstractMatrix{<:Real}) =
@@ -132,41 +132,41 @@ Calculates the support and weights of a discrete measure associated with a given
 - A tuple `(x, w)` where `x` is a vector of support points and `w` is a vector of corresponding weights.
 """
 function measure(
-    SR::StieltjesTransform,
-    c,
-    support_alg::AbstractSupportAlg,
-    weight_alg::AbstractWeightAlg,
-)
+        SR::StieltjesTransform,
+        c,
+        support_alg::AbstractSupportAlg,
+        weight_alg::AbstractWeightAlg,
+    )
     x = support(SR, support_alg)
     w = weights(SR, x, c, weight_alg)
-    x, w
+    return x, w
 end
 
 function measure(
-    SR::StieltjesTransform,
-    c,
-    support_alg::PolyRootsSupportAlg,
-    weight_alg::PolyWeightAlg,
-)
+        SR::StieltjesTransform,
+        c,
+        support_alg::PolyRootsSupportAlg,
+        weight_alg::PolyWeightAlg,
+    )
     Pstar = denominator(SR)
     P1 = numerator(SR)
 
     x = _support(Pstar, support_alg)
     w = _weights(P1, Pstar, x, weight_alg)
-    x, w
+    return x, w
 end
 
 function measure(
-    SR::StieltjesTransform,
-    c,
-    support_alg::EigvalSupportAlg,
-    weight_alg::EigvecWeightAlg,
-)
+        SR::StieltjesTransform,
+        c,
+        support_alg::EigvalSupportAlg,
+        weight_alg::EigvecWeightAlg,
+    )
     A = _companion_matrix(SR)
     vals = support_alg(A)
     vecs = weight_alg(A, vals)
 
-    vals, view(vecs, 1, :) .^ 2
+    return vals, view(vecs, 1, :) .^ 2
 end
 
 """
@@ -179,12 +179,12 @@ Calculates the support points of a discrete measure associated with a given Stie
 """
 function support(SR::StieltjesTransform, alg::PolyRootsSupportAlg)
     Pstar = denominator(SR)
-    _support(Pstar, alg)
+    return _support(Pstar, alg)
 end
 
 function support(SR::StieltjesTransform, alg::EigvalSupportAlg)
     A = _companion_matrix(SR)
-    alg(A)
+    return alg(A)
 end
 
 _support(P::Polynomial, alg::PolyRootsSupportAlg) =
@@ -202,25 +202,25 @@ Calculates the weights `w` of a discrete measure with support `x` such that the 
 - `alg::AbstractWeightAlg`:  The algorithm to use
 """
 function weights(SR::StieltjesTransform, x, c, alg::PolyWeightAlg)
-    _weights(numerator(SR), denominator(SR), x, alg)
+    return _weights(numerator(SR), denominator(SR), x, alg)
 end
 
 function weights(
-    SR::StieltjesTransform,
-    x::AbstractVector{𝕏},
-    c::AbstractVector{ℂ},
-    alg::LinearSolveWeightAlg,
-) where {𝕏,ℂ}
+        SR::StieltjesTransform,
+        x::AbstractVector{𝕏},
+        c::AbstractVector{ℂ},
+        alg::LinearSolveWeightAlg,
+    ) where {𝕏, ℂ}
     N = length(c)
 
     𝕋 = promote_type(𝕏, ℂ)
-    A = Matrix{𝕋}(undef, N+1, N+1)
-    b = Vector{𝕋}(undef, N+1)
+    A = Matrix{𝕋}(undef, N + 1, N + 1)
+    b = Vector{𝕋}(undef, N + 1)
     @views begin
-        A[1, :] = ones(𝕋, N+1)
+        A[1, :] = ones(𝕋, N + 1)
         for i in eachindex(x)
-            for j = 1:N
-                A[j+1, i] = x[i]^j
+            for j in 1:N
+                A[j + 1, i] = x[i]^j
             end
         end
         b[1] = one(𝕋)
@@ -228,25 +228,25 @@ function weights(
 
     end
 
-    alg.solver(A, b, alg.args...; alg.kwargs...)
+    return alg.solver(A, b, alg.args...; alg.kwargs...)
 end
 
 function weights(SR::StieltjesTransform, x, c, alg::EigvecWeightAlg)
     A = _companion_matrix(SR)
     v = alg(A)
-    v[1, :] .^ 2
+    return v[1, :] .^ 2
 end
 
 function _weights(num::Polynomial, den::Polynomial, x, alg::PolyWeightAlg)
     QP = num // Polynomials.derivative(den)
-    map(x) do xi
+    return map(x) do xi
         QP(xi)
     end
 end
 
 
 _companion_matrix(SR::StieltjesTransform) = _companion_matrix(SR.B, SR.C)
-# Just dispatch here to create wrapped companion matrix. 
+# Just dispatch here to create wrapped companion matrix.
 function _companion_matrix(B, C)
-    @views SymTridiagonal(-B, sqrt.(C[2:end]))
+    return @views SymTridiagonal(-B, sqrt.(C[2:end]))
 end

--- a/CanonicalMoments.jl/src/measure_transforms.jl
+++ b/CanonicalMoments.jl/src/measure_transforms.jl
@@ -9,14 +9,14 @@ This struct stores the raw moment sequence (`rm_seq`) and the corresponding cano
 - `rm_seq::RawMomentSequence`: The raw moment sequence.
 - `cm_seq::CanonicalMomentSequence`: The canonical moment sequence.
 """
-struct DiscreteMeasureTransform1{ℝ,ℂ}
+struct DiscreteMeasureTransform1{ℝ, ℂ}
     rm_seq::ℝ
     cm_seq::ℂ
     function DiscreteMeasureTransform1(
-        rm_seq::ℝ,
-        cm_seq::ℂ,
-    ) where {ℝ<:RawMomentSequence,ℂ<:CanonicalMomentSequence}
-        new{ℝ,ℂ}(rm_seq, cm_seq)
+            rm_seq::ℝ,
+            cm_seq::ℂ,
+        ) where {ℝ <: RawMomentSequence, ℂ <: CanonicalMomentSequence}
+        return new{ℝ, ℂ}(rm_seq, cm_seq)
     end
 end
 
@@ -29,7 +29,7 @@ This constructor creates a `DiscreteMeasureTransform1` object using a given `Raw
 - `rm_seq::RawMomentSequence`: The raw moment sequence defining the transformation.
 """
 function DiscreteMeasureTransform1(rm_seq::RawMomentSequence)
-    DiscreteMeasureTransform1(rm_seq, CanonicalMomentSequence(rm_seq))
+    return DiscreteMeasureTransform1(rm_seq, CanonicalMomentSequence(rm_seq))
 end
 
 """
@@ -43,10 +43,10 @@ Constructs a `DiscreteMeasure` from a sequence of free canonical moments.
 - `weight_alg = PolyWeightAlg()`: The algorithm used to compute the weights of the discrete measure. Defaults to `PolyWeightAlg()`.
 """
 function (dmt::DiscreteMeasureTransform1)(
-    p_free;
-    support_alg = EigvalSupportAlg(),
-    weight_alg = PolyWeightAlg(),
-)
+        p_free;
+        support_alg = EigvalSupportAlg(),
+        weight_alg = PolyWeightAlg(),
+    )
     rms = dmt.rm_seq
     cms = dmt.cm_seq
 
@@ -55,5 +55,5 @@ function (dmt::DiscreteMeasureTransform1)(
 
     SR = StieltjesTransform(cms, p_free)
     x, w = measure(SR, moments(rms), support_alg, weight_alg)
-    DiscreteMeasure(collect(x), collect(w)) # Want to avoid all ways symbolic arrays can creep in.
+    return DiscreteMeasure(collect(x), collect(w)) # Want to avoid all ways symbolic arrays can creep in.
 end

--- a/CanonicalMoments.jl/src/moment_conversion.jl
+++ b/CanonicalMoments.jl/src/moment_conversion.jl
@@ -13,8 +13,8 @@ This function calculates the ζ sequence [1, pg viii] from a vector of canonical
 function _ζ(p)
     ζ = similar(p)
     ζ[1] = p[1]
-    for k = 2:length(p)
-        ζ[k] = (1 - p[k-1]) * p[k] # Dette pg viii
+    for k in 2:length(p)
+        ζ[k] = (1 - p[k - 1]) * p[k] # Dette pg viii
     end
     return ζ
 end
@@ -38,8 +38,8 @@ This function implements the transformation of center for moments.  Given a sequ
 """
 function _moment_center_transform(sequence, a, b)
     n = length(sequence)
-    mapreduce(+, 1:n; init = (a-b)^n) do i
-        binomial(n, i) * sequence[i] * (a-b)^(n-i)
+    return mapreduce(+, 1:n; init = (a - b)^n) do i
+        binomial(n, i) * sequence[i] * (a - b)^(n - i)
     end
 end
 
@@ -59,7 +59,7 @@ This function applies the center transformation to each moment in the input sequ
 - A vector of moments centered around `b`, with the same length as the input `sequence`.
 """
 function _sequence_center_transform(sequence, a, b)
-    map(eachindex(sequence)) do n
+    return map(eachindex(sequence)) do n
         @views _moment_center_transform(sequence[1:n], a, b)
     end
 end
@@ -81,7 +81,7 @@ This function transforms raw moments, defined on the interval `[lb, ub]`, to mom
 [1] Dette, H., and Studden, W. J. (1997). The Theory of Canonical Moments with Applications in Statistics, Probability, and Analysis. Wiley-Interscience, New York. 
 """
 function _raw2normed(moments, lb, ub)
-    map(moments, eachindex(moments)) do _, n
+    return map(moments, eachindex(moments)) do _, n
         s = mapreduce(+, 1:n, moments) do j, mj
             binomial(n, j) * (-lb)^(n - j) * mj
         end
@@ -103,7 +103,7 @@ This function performs the inverse transformation of _raw2normed, converting mom
 A vector of raw moments on the interval [lb, ub].
 """
 function _normed2raw(moments, lb, ub)
-    map(moments, eachindex(moments)) do _, n
+    return map(moments, eachindex(moments)) do _, n
         s = mapreduce(+, 1:n, moments) do j, mj
             binomial(n, j) * (ub - lb)^j * lb^(n - j) * mj
         end
@@ -129,7 +129,7 @@ This function transforms a sequence of raw moments on the unit interval to canon
 function _normed2canonical(nrms)
     # TODO improve container type
     N = length(nrms)
-    if N == 1
+    return if N == 1
         [first(nrms)]
     elseif N == 2
         [first(nrms), _p2(nrms)]
@@ -168,22 +168,22 @@ function QD(c)
     #TODO rewrite... ported from Stenger code.
     c̄ = vcat(1, c)
     rg = length(c)
-    Mat = [zeros(rg), [c̄[i+1] / c̄[i] for i = 1:(rg)]]
-    for i = 3:(rg+1)
+    Mat = [zeros(rg), [c̄[i + 1] / c̄[i] for i in 1:(rg)]]
+    for i in 3:(rg + 1)
         if i % 2 == 1
             push!(
                 Mat,
                 [
-                    Mat[i-1][t+1] - Mat[i-1][t] + Mat[i-2][t+1] for
-                    t = 1:(length(Mat[i-1])-1)
+                    Mat[i - 1][t + 1] - Mat[i - 1][t] + Mat[i - 2][t + 1] for
+                        t in 1:(length(Mat[i - 1]) - 1)
                 ],
             )
         else
             push!(
                 Mat,
                 [
-                    Mat[i-1][t+1] / Mat[i-1][t] * Mat[i-2][t+1] for
-                    t = 1:(length(Mat[i-1])-1)
+                    Mat[i - 1][t + 1] / Mat[i - 1][t] * Mat[i - 2][t + 1] for
+                        t in 1:(length(Mat[i - 1]) - 1)
                 ],
             )
         end
@@ -191,12 +191,12 @@ function QD(c)
     # for i in eachindex(Mat)
     #     println("$(Mat[i])\n")
     # end
-    ζ = [Mat[i][1] for i = 2:(length(Mat))]
+    ζ = [Mat[i][1] for i in 2:(length(Mat))]
     # @show ζ
     p = similar(ζ)
     p[1] = ζ[1]
-    for i = 2:(length(ζ))
-        p[i] = ζ[i] / (1 - p[i-1])
+    for i in 2:(length(ζ))
+        p[i] = ζ[i] / (1 - p[i - 1])
     end
     return p
 end

--- a/CanonicalMoments.jl/src/moment_sequences.jl
+++ b/CanonicalMoments.jl/src/moment_sequences.jl
@@ -11,14 +11,14 @@ within the interval ``[lb, ub] ⊆ ℝ``.
 - `lb`: The lower bound of domain.
 - `ub`: The upper bound of domain.
 """
-struct RawMomentSequence{𝕋<:AbstractVector,𝕃,𝕌} <: AbstractMomentSequence
+struct RawMomentSequence{𝕋 <: AbstractVector, 𝕃, 𝕌} <: AbstractMomentSequence
     moments::𝕋
     lb::𝕃
     ub::𝕌
 
-    function RawMomentSequence(moments::𝕋, lb::𝕃, ub::𝕌) where {𝕋,𝕃,𝕌}
+    function RawMomentSequence(moments::𝕋, lb::𝕃, ub::𝕌) where {𝕋, 𝕃, 𝕌}
         # _verify_bounds(lb, ub)
-        new{𝕋,𝕃,𝕌}(moments, lb, ub)
+        return new{𝕋, 𝕃, 𝕌}(moments, lb, ub)
     end
 end
 
@@ -32,13 +32,13 @@ Represents a sequence of raw moments after the domain is transformed to the unit
 - `lb`: The lower bound of the domain of the source `RawMomentSequence`
 - `ub`: The upper bound of the domain of the source `RawMomentSequence`
 """
-struct UnitIntervalRawMomentSequence{𝕋<:AbstractVector,𝕃,𝕌} <: AbstractMomentSequence
+struct UnitIntervalRawMomentSequence{𝕋 <: AbstractVector, 𝕃, 𝕌} <: AbstractMomentSequence
     moments::𝕋
     lb::𝕃
     ub::𝕌
-    function UnitIntervalRawMomentSequence(moments::𝕋, lb::𝕃, ub::𝕌) where {𝕋,𝕃,𝕌}
+    function UnitIntervalRawMomentSequence(moments::𝕋, lb::𝕃, ub::𝕌) where {𝕋, 𝕃, 𝕌}
         # _verify_bounds(lb, ub)
-        new{𝕋,𝕃,𝕌}(moments, lb, ub)
+        return new{𝕋, 𝕃, 𝕌}(moments, lb, ub)
     end
 end
 
@@ -53,13 +53,13 @@ where ``x̄`` is the mean of the random variable ``x`` within the interval ``[lb
 - `lb`: The lower bound of the domain.
 - `ub`: The upper bound of the domain.
 """
-struct CentralMomentSequence{𝕋<:AbstractVector,𝕃,𝕌} <: AbstractMomentSequence
+struct CentralMomentSequence{𝕋 <: AbstractVector, 𝕃, 𝕌} <: AbstractMomentSequence
     moments::𝕋
     lb::𝕃
     ub::𝕌
-    function CentralMomentSequence(moments::𝕋, lb::𝕃, ub::𝕌) where {𝕋,𝕃,𝕌}
+    function CentralMomentSequence(moments::𝕋, lb::𝕃, ub::𝕌) where {𝕋, 𝕃, 𝕌}
         # _verify_bounds(lb, ub)
-        new{𝕋,𝕃,𝕌}(moments, lb, ub)
+        return new{𝕋, 𝕃, 𝕌}(moments, lb, ub)
     end
 end
 
@@ -73,13 +73,13 @@ Represents a sequence of canonical moments.
 - `lb`: The lower bound of the domain.
 - `ub`: The upper bound of the domain.
 """
-struct CanonicalMomentSequence{𝕋<:AbstractVector,𝕃,𝕌} <: AbstractMomentSequence
+struct CanonicalMomentSequence{𝕋 <: AbstractVector, 𝕃, 𝕌} <: AbstractMomentSequence
     moments::𝕋
     lb::𝕃
     ub::𝕌
-    function CanonicalMomentSequence(moments::𝕋, lb::𝕃, ub::𝕌) where {𝕋,𝕃,𝕌}
+    function CanonicalMomentSequence(moments::𝕋, lb::𝕃, ub::𝕌) where {𝕋, 𝕃, 𝕌}
         # _verify_bounds(lb, ub)
-        new{𝕋,𝕃,𝕌}(moments, lb, ub)
+        return new{𝕋, 𝕃, 𝕌}(moments, lb, ub)
     end
 end
 
@@ -89,7 +89,7 @@ end
 This function converts central moments to raw moments using the provided mean, μ.
 """
 function RawMomentSequence(cms::CentralMomentSequence, μ)
-    RawMomentSequence(
+    return RawMomentSequence(
         _sequence_center_transform(moments(cms), μ, 0),
         lbound(cms),
         ubound(cms),
@@ -97,7 +97,7 @@ function RawMomentSequence(cms::CentralMomentSequence, μ)
 end
 
 function RawMomentSequence(nrms::UnitIntervalRawMomentSequence)
-    RawMomentSequence(
+    return RawMomentSequence(
         _normed2raw(moments(nrms), lbound(nrms), ubound(nrms)),
         lbound(nrms),
         ubound(nrms),
@@ -107,12 +107,12 @@ end
 function CentralMomentSequence(rms::RawMomentSequence)
     m = moments(rms)
     μ = mean(rms)
-    CentralMomentSequence(_sequence_center_transform(m, 0, μ), lbound(rms), ubound(rms))
+    return CentralMomentSequence(_sequence_center_transform(m, 0, μ), lbound(rms), ubound(rms))
 end
 
 function UnitIntervalRawMomentSequence(rms::RawMomentSequence)
     nrm = _raw2normed(moments(rms), lbound(rms), ubound(rms))
-    UnitIntervalRawMomentSequence(nrm, lbound(rms), ubound(rms))
+    return UnitIntervalRawMomentSequence(nrm, lbound(rms), ubound(rms))
 end
 
 """
@@ -121,15 +121,15 @@ end
 This function first converts the central moments to raw moments using the provided mean, μ, and then transforms the resulting `RawMomentSequence` to a `UnitIntervalRawMomentSequence`.
 """
 function UnitIntervalRawMomentSequence(cms::CentralMomentSequence, μ)
-    UnitIntervalRawMomentSequence(RawMomentSequence(cms, μ))
+    return UnitIntervalRawMomentSequence(RawMomentSequence(cms, μ))
 end
 
 function CanonicalMomentSequence(nrms::UnitIntervalRawMomentSequence)
-    CanonicalMomentSequence(_normed2canonical(moments(nrms)), lbound(nrms), ubound(nrms))
+    return CanonicalMomentSequence(_normed2canonical(moments(nrms)), lbound(nrms), ubound(nrms))
 end
 
 function CanonicalMomentSequence(rms::RawMomentSequence)
-    CanonicalMomentSequence(UnitIntervalRawMomentSequence(rms))
+    return CanonicalMomentSequence(UnitIntervalRawMomentSequence(rms))
 end
 
 """
@@ -151,7 +151,7 @@ This uses the property that odd-numbered canonical moments are ``1/2`` for symme
 """
 function issymmetric(cms::CanonicalMomentSequence; kwargs...)
     odd_moments = @views moments(cms)[1:2:end]
-    all(≈(1/2; kwargs...), odd_moments)
+    return all(≈(1 / 2; kwargs...), odd_moments)
 end
 
 """
@@ -189,8 +189,8 @@ Returns the upper bound of the sequence domain.
 """
 ubound(m::AbstractMomentSequence) = m.ub
 
-function isapprox(a::𝕋, b::𝕋; kwargs...) where {𝕋<:AbstractMomentSequence}
-    isapprox(moments(a), moments(b); kwargs...) &&
+function isapprox(a::𝕋, b::𝕋; kwargs...) where {𝕋 <: AbstractMomentSequence}
+    return isapprox(moments(a), moments(b); kwargs...) &&
         lbound(a) == lbound(b) &&
         ubound(a) == ubound(b)
 end

--- a/CanonicalMoments.jl/src/orthopoly_roots.jl
+++ b/CanonicalMoments.jl/src/orthopoly_roots.jl
@@ -9,11 +9,11 @@ This is used for dispatch for AD with respect to the polynomial coefficients.
 - `root_solver`: function to call for finding the roots
 """
 function simple_real_roots(C, root_solver, args...; kwargs...)
-    Real.(root_solver(C, args...; kwargs...))
+    return Real.(root_solver(C, args...; kwargs...))
 end
 
 function simple_real_roots(P::AbstractPolynomial, root_solver, args...; kwargs...)
-    simple_real_roots(coeffs(P), root_solver, args...; kwargs...)
+    return simple_real_roots(coeffs(P), root_solver, args...; kwargs...)
 end
 
 
@@ -21,27 +21,27 @@ function quadratic_eq_sridhare(coeffs)
     @assert length(coeffs) == 3
     c, b, a = coeffs
     X = similar(coeffs, 2)
-    X[1] = (-b - sqrt(b^2 - 4*a*c)) / (2a)
-    X[2] = (-b + sqrt(b^2 - 4*a*c)) / (2a)
-    X
+    X[1] = (-b - sqrt(b^2 - 4 * a * c)) / (2a)
+    X[2] = (-b + sqrt(b^2 - 4 * a * c)) / (2a)
+    return X
 end
 
 function quadratic_eq_fagnano(coeffs)
     @assert length(coeffs) == 3
     c, b, a = coeffs
     X = similar(coeffs, 2)
-    X[1] = 2c / (-b + sqrt(b^2 - 4*a*c))
-    X[2] = 2c / (-b - sqrt(b^2 - 4*a*c))
-    X
+    X[1] = 2c / (-b + sqrt(b^2 - 4 * a * c))
+    X[2] = 2c / (-b - sqrt(b^2 - 4 * a * c))
+    return X
 end
 
 function quadratic_eq_fagnano_mod(coeffs)
     @assert length(coeffs) == 3
     c, b, a = coeffs
     X = similar(coeffs, 2)
-    X[1] = 2c / (-b*(1 - sqrt(1 - 4*a*c/b^2)))
-    X[2] = 2c / (-b*(1 + sqrt(1 - 4*a*c/b^2)))
-    X
+    X[1] = 2c / (-b * (1 - sqrt(1 - 4 * a * c / b^2)))
+    X[2] = 2c / (-b * (1 + sqrt(1 - 4 * a * c / b^2)))
+    return X
 end
 
 # function tightest_quadratic(coeffs)
@@ -91,9 +91,9 @@ which simplifies the process of finding the roots. It assumes that `a` is implic
 """
 function _depressed_cubic(coeffs)
     d, c, b, _ = coeffs
-    p = -b^2/3 + c
-    q = 2*b^3/27 - b*c/3 + d
-    p, q
+    p = -b^2 / 3 + c
+    q = 2 * b^3 / 27 - b * c / 3 + d
+    return p, q
 end
 
 """
@@ -114,9 +114,9 @@ function simple_real_cubic_eq(coeffs)
     _, _, b, _ = coeffs
     p, q = _depressed_cubic(coeffs)
 
-    s = map(0:2) do k
-        θ = acos(-3*sqrt(3)*q / (2*sqrt(-p^3)))/3
-        2*sqrt(-p/3)*cos(θ - 2*k*π/3) - b/3
+    return s = map(0:2) do k
+        θ = acos(-3 * sqrt(3) * q / (2 * sqrt(-p^3))) / 3
+        2 * sqrt(-p / 3) * cos(θ - 2 * k * π / 3) - b / 3
     end
 end
 
@@ -142,18 +142,18 @@ This function computes the roots of a quartic equation of the form `x⁴ + bx³ 
 function simple_real_quartic_eq(coeffs)
     e, d, c, b, _ = coeffs
 
-    A = 2c - 3*b^2/4
-    B = 2*d - b*c + b^3/4
-    Δ0 = c^2 + 12e - 3b*d
-    Δ1 = 27*b^2*e - 9*b*c*d + 2*c^3 - 72*c*e + 27*d^2
+    A = 2c - 3 * b^2 / 4
+    B = 2 * d - b * c + b^3 / 4
+    Δ0 = c^2 + 12e - 3b * d
+    Δ1 = 27 * b^2 * e - 9 * b * c * d + 2 * c^3 - 72 * c * e + 27 * d^2
 
-    θ = acos(Δ1 / (2*sqrt(Δ0^3)))
-    Z = (2*sqrt(Δ0)*cos(θ/3) - A)/3
+    θ = acos(Δ1 / (2 * sqrt(Δ0^3)))
+    Z = (2 * sqrt(Δ0) * cos(θ / 3) - A) / 3
 
     X = similar(coeffs, 4)
-    X[1] = -b/4 + 1/2*(sqrt(Z) + sqrt(-(A + Z + B/sqrt(Z))))
-    X[2] = -b/4 + 1/2*(sqrt(Z) - sqrt(-(A + Z + B/sqrt(Z))))
-    X[3] = -b/4 - 1/2*(sqrt(Z) - sqrt(-(A + Z - B/sqrt(Z))))
-    X[4] = -b/4 - 1/2*(sqrt(Z) + sqrt(-(A + Z - B/sqrt(Z))))
-    X
+    X[1] = -b / 4 + 1 / 2 * (sqrt(Z) + sqrt(-(A + Z + B / sqrt(Z))))
+    X[2] = -b / 4 + 1 / 2 * (sqrt(Z) - sqrt(-(A + Z + B / sqrt(Z))))
+    X[3] = -b / 4 - 1 / 2 * (sqrt(Z) - sqrt(-(A + Z - B / sqrt(Z))))
+    X[4] = -b / 4 - 1 / 2 * (sqrt(Z) + sqrt(-(A + Z - B / sqrt(Z))))
+    return X
 end

--- a/CanonicalMoments.jl/src/stieltjes.jl
+++ b/CanonicalMoments.jl/src/stieltjes.jl
@@ -13,7 +13,7 @@ This follows the 1st form recurrence relations defined in defined in [NIST digit
 - `B`: A vector representing the ``B`` coefficients in the recurrence relation.
 - `C`: A vector representing the ``C`` coefficients in the recurrence relation.
 """
-struct StieltjesTransform{𝕋,𝔹<:AbstractVector{𝕋},ℂ<:AbstractVector{𝕋}}
+struct StieltjesTransform{𝕋, 𝔹 <: AbstractVector{𝕋}, ℂ <: AbstractVector{𝕋}}
     B::𝔹
     C::ℂ
 end
@@ -30,13 +30,13 @@ end
 function StieltjesTransform(cms::CanonicalMomentSequence, p_free)
     lb = lbound(cms)
     ub = ubound(cms)
-    _stieltjes_transform(moments(cms), p_free, lb, ub)
+    return _stieltjes_transform(moments(cms), p_free, lb, ub)
 end
 
 #@register_symbolic _stieltjes_transform(cms, p_free, lb, ub)
 function _stieltjes_transform(cms, p_free, lb, ub)
     p = vcat(cms, p_free)
-    _stieltjes_transform(p, lb, ub)
+    return _stieltjes_transform(p, lb, ub)
 end
 
 function _stieltjes_transform(p::AbstractVector{T}, lb, ub) where {T}
@@ -45,19 +45,19 @@ function _stieltjes_transform(p::AbstractVector{T}, lb, ub) where {T}
     Δ = ub - lb
     Δ2 = Δ^2
 
-    B = Vector{T}(undef, N+1)
-    B[1] = -lb - Δ*ζ[1]
+    B = Vector{T}(undef, N + 1)
+    B[1] = -lb - Δ * ζ[1]
     for (i, k) in enumerate(2:2:length(p))
-        B[i+1] = -lb - Δ*(ζ[k] + ζ[k+1])
+        B[i + 1] = -lb - Δ * (ζ[k] + ζ[k + 1])
     end
 
-    C = Vector{T}(undef, N+1)
+    C = Vector{T}(undef, N + 1)
     C[1] = one(T)
-    for (i, k) in enumerate(1:2:(length(p)-1))
-        C[i+1] = Δ2*ζ[k]*ζ[k+1]
+    for (i, k) in enumerate(1:2:(length(p) - 1))
+        C[i + 1] = Δ2 * ζ[k] * ζ[k + 1]
     end
 
-    StieltjesTransform(B, C)
+    return StieltjesTransform(B, C)
 end
 
 """
@@ -67,7 +67,7 @@ Evaluates the Stieltjes transform at a given point `z`.
 """
 function (S::StieltjesTransform)(z)
     R = numerator(S) // denominator(S)
-    R(z)
+    return R(z)
 end
 
 """
@@ -76,12 +76,14 @@ end
 Computes the denominator polynomial of the Stieltjes transform's rational function representation.
 """
 function denominator(S::StieltjesTransform{𝕋}) where {𝕋}
-    last(forwardrecurrence(
-        ones(length(S.B)),      #A
-        S.B,
-        S.C,
-        Polynomial{𝕋}([0, 1]),
-    ))
+    return last(
+        forwardrecurrence(
+            ones(length(S.B)),      #A
+            S.B,
+            S.C,
+            Polynomial{𝕋}([0, 1]),
+        )
+    )
 end
 
 """
@@ -91,10 +93,12 @@ Computes the numerator polynomial of the Stieltjes transform's rational function
 """
 function numerator(S::StieltjesTransform{𝕋}) where {𝕋}
     A = ones(length(S.B))
-    @views last(forwardrecurrence(
-        A[2:end],      #A
-        S.B[2:end],
-        S.C[2:end],
-        Polynomial{𝕋}([0, 1]),
-    ))
+    return @views last(
+        forwardrecurrence(
+            A[2:end],      #A
+            S.B[2:end],
+            S.C[2:end],
+            Polynomial{𝕋}([0, 1]),
+        )
+    )
 end

--- a/CanonicalMoments.jl/test/moment_sequence.jl
+++ b/CanonicalMoments.jl/test/moment_sequence.jl
@@ -11,29 +11,29 @@ import CanonicalMoments:
     isvalidbounds,
     AbstractMomentSequence
 
-seq_types = filter(x->!isabstracttype(x), subtypes(AbstractMomentSequence))
+seq_types = filter(x -> !isabstracttype(x), subtypes(AbstractMomentSequence))
 
 support_algs = (
     EigvalSupportAlg(),
     EigvalSupportAlg(eigvals ∘ eigen),
     PolyRootsSupportAlg(),
-    PolyRootsSupportAlg(c->sort(Real.(PolynomialRoots.roots(c)))),
+    PolyRootsSupportAlg(c -> sort(Real.(PolynomialRoots.roots(c)))),
 )
 weight_algs = (PolyWeightAlg(), LinearSolveWeightAlg(), EigvecWeightAlg())
 
 #normal distribution, central -> raw and raw -> central
 μN = 5.0
 σN = 3.0
-rawsN = [μN, μN^2+σN^2, μN^3+3μN*σN^2, μN^4 + 6μN^2*σN^2 + 3σN^4]
-centralsN = [0.0, σN^2, 0.0, 3*σN^4]
+rawsN = [μN, μN^2 + σN^2, μN^3 + 3μN * σN^2, μN^4 + 6μN^2 * σN^2 + 3σN^4]
+centralsN = [0.0, σN^2, 0.0, 3 * σN^4]
 
 #uniform distribution, central -> raw and raw -> central
 # Analytical raw/central moments from https://mathworld.wolfram.com/UniformDistribution.html
 n = 5
 as = (-10, 0, 10)
 bs = ((-1, 0, 1), (1,), (20,))
-uniform_raw_moment(a, b, n) = (b^(n+1) - a^(n+1)) / ((n+1)*(b-a))
-uniform_central_moment(a, b, n) = ((a-b)^n + (b-a)^n) / (2^(n+1)*(n+1))
+uniform_raw_moment(a, b, n) = (b^(n + 1) - a^(n + 1)) / ((n + 1) * (b - a))
+uniform_central_moment(a, b, n) = ((a - b)^n + (b - a)^n) / (2^(n + 1) * (n + 1))
 uniform_canonical_moment(n) = beta_canonical_moment(0, 0, n)   # uniform [0,1]
 
 # Dette Example 1.3.6
@@ -41,11 +41,11 @@ beta_raw_moment(α, β, n) = beta(β + 1 + n, α + 1) / beta(β + 1, α + 1)
 
 # Dette Eq. 1.3.11
 function beta_canonical_moment(α, β, n)
-    if isodd(n)
-        j = (n + 1)/2
+    return if isodd(n)
+        j = (n + 1) / 2
         (β + j) / (2j + α + β)
     else
-        j = n/2
+        j = n / 2
         j / (2j + 1 + α + β)
     end
 end
@@ -59,7 +59,7 @@ end
 
 @testset "Sequence Center Transforms" begin
     @test _sequence_center_transform(SVector(centralsN...), μN, 0) isa
-          Union{SVector,MVector} #MVector due to https://github.com/JuliaArrays/StaticArrays.jl/issues/1032
+        Union{SVector, MVector} #MVector due to https://github.com/JuliaArrays/StaticArrays.jl/issues/1032
     @test _sequence_center_transform(centralsN, μN, 0) ≈ rawsN
     @test _sequence_center_transform(rawsN, 0, μN) ≈ centralsN
 
@@ -110,7 +110,7 @@ end
             cms = CanonicalMomentSequence(x, Ω...)
 
             @test issymmetric(cms) == false
-            x[1:2:end] .= 1/2
+            x[1:2:end] .= 1 / 2
             @test issymmetric(cms) == true
         end
 
@@ -176,11 +176,11 @@ end
         end
 
         #Arc-Sine Distribution
-        α = -1/2
-        β = -1/2
+        α = -1 / 2
+        β = -1 / 2
         for j in (1, 2, n)
             rms = RawMomentSequence(beta_raw_moment.(α, β, 1:j), 0, 1)
-            cms = CanonicalMomentSequence(fill(1/2, j), 0, 1)
+            cms = CanonicalMomentSequence(fill(1 / 2, j), 0, 1)
             @test CanonicalMomentSequence(rms) ≈ cms
         end
     end
@@ -188,9 +188,9 @@ end
 
 # Dette Thm 1.3.2
 @testset "Domain Interval Invariance" begin
-    a1 = 0;
+    a1 = 0
     b1 = 1
-    a2 = -3;
+    a2 = -3
     b2 = 11
 
     r1 = RawMomentSequence(uniform_raw_moment.(a1, b1, 1:n), a1, b1)
@@ -202,7 +202,7 @@ end
 @testset "Raw <-> Canonical Moment Maps" begin
     ns = (1, 2, 3, 4)
     for n in ns
-        m = 2n+1
+        m = 2n + 1
         as = (1, 0)
         bs = (10, 1)
 
@@ -217,7 +217,7 @@ end
 
             for support_alg in support_algs
                 for weight_alg in weight_algs
-                    μ = dmt(moments(cms)[(n+1):end]; support_alg, weight_alg)
+                    μ = dmt(moments(cms)[(n + 1):end]; support_alg, weight_alg)
 
                     x = support(μ)
                     w = weights(μ)
@@ -226,7 +226,7 @@ end
                     @test sum(w) ≈ 1
 
                     for (k, truth) in enumerate(raws_truth[i])
-                        expectation(x->x^k, μ) ≈ truth
+                        expectation(x -> x^k, μ) ≈ truth
                     end
                 end
             end

--- a/CanonicalMoments.jl/test/runtests.jl
+++ b/CanonicalMoments.jl/test/runtests.jl
@@ -30,7 +30,7 @@ using Test
 #     @test clamp_domain([Interval(-2, -1)], lb, ub) == []
 #     @test clamp_domain([Interval(2, 3)], lb, ub) == []
 #     @test clamp_domain([
-#         Interval(.1, .9), 
+#         Interval(.1, .9),
 #         Interval(-.1, .1),
 #         Interval(lb.lo, .1),
 #         Interval(.1, 1.1),
@@ -58,7 +58,7 @@ using Test
 #         for _setup in setup
 #             p = _setup.free
 #             for (lb, ub, _c, _p) in zip(ql, qu, c, p)
-#                 can = moments_to_canonical(lb, ub, _c, _p) 
+#                 can = moments_to_canonical(lb, ub, _c, _p)
 #                 @test all(@. 0 ≤ can ≤ 1)
 
 #                 can_IA = moments_to_canonical(Interval(lb), Interval(ub), Interval.(_c), Interval.(_p))

--- a/CanonicalMoments.jl/test/stenger_setup.jl
+++ b/CanonicalMoments.jl/test/stenger_setup.jl
@@ -21,23 +21,23 @@ c1 = [
 c2 = [
     [1320.42, 2.1632e6], # means and 2nd moments
     [30.0, 949.137],
-    [50.0, 7501/3.0],
-    [54.5, 8911/3.0],
+    [50.0, 7501 / 3.0],
+    [54.5, 8911 / 3.0],
 ]
 
 c3 = [
     [1320.42, 2.1632e6, 4.18e9], # means and 3rd moments
     [30.0, 949.137, 31422.3],
-    [50.0, 7501/3.0, 125050],
-    [54.5, 8911/3.0, 647569/4],
+    [50.0, 7501 / 3.0, 125050],
+    [54.5, 8911 / 3.0, 647569 / 4],
 ]
 
 threshold = 4
 
 setup1 = [
-    (free = [fill(0.5, 2) for _ = 1:length(c1)], res = 0.8346769701),
-    (free = [fill(0.25, 2) for _ = 1:length(c1)], res = 0.8423597615),
-    (free = [fill(0.75, 2) for _ = 1:length(c1)], res = 0.8355977711),
+    (free = [fill(0.5, 2) for _ in 1:length(c1)], res = 0.8346769701),
+    (free = [fill(0.25, 2) for _ in 1:length(c1)], res = 0.8423597615),
+    (free = [fill(0.75, 2) for _ in 1:length(c1)], res = 0.8355977711),
     (
         free = [
             [0.11008426115113379, 0.4913831957970459],
@@ -50,9 +50,9 @@ setup1 = [
 ]
 
 setup2 = [
-    (free = [fill(0.5, 3) for _ = 1:length(c2)], res = 0.9084523325),
-    (free = [fill(0.25, 3) for _ = 1:length(c2)], res = 0.9158574604),
-    (free = [fill(0.75, 3) for _ = 1:length(c2)], res = 0.9429896112),
+    (free = [fill(0.5, 3) for _ in 1:length(c2)], res = 0.9084523325),
+    (free = [fill(0.25, 3) for _ in 1:length(c2)], res = 0.9158574604),
+    (free = [fill(0.75, 3) for _ in 1:length(c2)], res = 0.9429896112),
     (
         free = [
             [0.11008426115113379, 0.4913831957970459, 0.5651453592612876],
@@ -65,9 +65,9 @@ setup2 = [
 ]
 
 setup3 = [
-    (free = [fill(0.5, 4) for _ = 1:length(c3)], res = 0.9385050420),
-    (free = [fill(0.25, 4) for _ = 1:length(c3)], res = 0.9267572769),
-    (free = [fill(0.75, 4) for _ = 1:length(c3)], res = 0.9327169677),
+    (free = [fill(0.5, 4) for _ in 1:length(c3)], res = 0.938505042),
+    (free = [fill(0.25, 4) for _ in 1:length(c3)], res = 0.9267572769),
+    (free = [fill(0.75, 4) for _ in 1:length(c3)], res = 0.9327169677),
     (
         free = [
             [

--- a/DiscreteMeasures.jl/docs/make.jl
+++ b/DiscreteMeasures.jl/docs/make.jl
@@ -12,6 +12,6 @@ makedocs(;
     modules = [DiscreteMeasures],
     authors = "TODO",
     sitename = "DiscreteMeasures.jl",
-    format = Documenter.HTML(;),
+    format = Documenter.HTML(),
     pages = ["Home" => "index.md"],
 )

--- a/DiscreteMeasures.jl/ext/IntervalArithmeticExt.jl
+++ b/DiscreteMeasures.jl/ext/IntervalArithmeticExt.jl
@@ -5,11 +5,11 @@ using DiscreteMeasures, IntervalArithmetic
 println("Load Ext")
 function DiscreteMeasures.clamp_domain(x::Interval, lb, ub)
     bounds = Interval(lb, ub)
-    intersect(x, bounds)
+    return intersect(x, bounds)
 end
 
 function DiscreteMeasures.clamp_weight(w::Interval{T}, maxw::T = one(T)) where {T}
-    clamp_domain(w, zero(T), maxw)
+    return clamp_domain(w, zero(T), maxw)
 end
 
 end

--- a/DiscreteMeasures.jl/src/DiscreteMeasures.jl
+++ b/DiscreteMeasures.jl/src/DiscreteMeasures.jl
@@ -24,15 +24,15 @@ w = [0.2, 0.3, 0.5]
 dm = DiscreteMeasure(x, w)
 ```
 """
-struct DiscreteMeasure{𝕋,𝕏,𝕎} <: AbstractDiscreteMeasure
+struct DiscreteMeasure{𝕋, 𝕏, 𝕎} <: AbstractDiscreteMeasure
     n::Int64
     x::𝕏
     w::𝕎
 
-    function DiscreteMeasure(x::𝕏, w::𝕎) where {𝕋,𝕏<:AbstractVector{𝕋},𝕎<:AbstractVector}
+    function DiscreteMeasure(x::𝕏, w::𝕎) where {𝕋, 𝕏 <: AbstractVector{𝕋}, 𝕎 <: AbstractVector}
         @assert length(w) == length(x)
         @assert allequal(length, x)
-        new{𝕋,𝕏,𝕎}(length(first(x)), x, w)
+        return new{𝕋, 𝕏, 𝕎}(length(first(x)), x, w)
     end
 end
 
@@ -71,14 +71,14 @@ dm2 = DiscreteMeasure(x2, w2)
 pdm = ProductDiscreteMeasure([dm1, dm2])
 ```
 """
-struct ProductDiscreteMeasure{𝕄,𝕏,𝕎} <: AbstractDiscreteMeasure
+struct ProductDiscreteMeasure{𝕄, 𝕏, 𝕎} <: AbstractDiscreteMeasure
     marginals::𝕄
     x::𝕏
     w::𝕎
 
-    function ProductDiscreteMeasure(dms::𝕄) where {𝕄<:AbstractVector{<:DiscreteMeasure}}
+    function ProductDiscreteMeasure(dms::𝕄) where {𝕄 <: AbstractVector{<:DiscreteMeasure}}
         x, w = _product_measure(support.(dms), weights.(dms))
-        new{𝕄,typeof(x),typeof(w)}(dms, x, w)
+        return new{𝕄, typeof(x), typeof(w)}(dms, x, w)
     end
 end
 
@@ -92,7 +92,7 @@ function ProductDiscreteMeasure(pdms::ProductDiscreteMeasure, dms::DiscreteMeasu
     x = vcat(support.(marginals(pdms)), [support(dms)])
     w = vcat(weights.(marginals(pdms)), [weights(dms)])
 
-    ProductDiscreteMeasure(DiscreteMeasure.(x, w))
+    return ProductDiscreteMeasure(DiscreteMeasure.(x, w))
 end
 
 """
@@ -101,23 +101,23 @@ end
 Construct a product measure between a product measure and a vector of discrete measures
 """
 function ProductDiscreteMeasure(
-    pdms::ProductDiscreteMeasure,
-    dms::𝕋,
-) where {𝕋<:AbstractVector{<:DiscreteMeasure}}
+        pdms::ProductDiscreteMeasure,
+        dms::𝕋,
+    ) where {𝕋 <: AbstractVector{<:DiscreteMeasure}}
     x = vcat(support.(marginals(pdms)), support.(dms))
     w = vcat(weights.(marginals(pdms)), weights.(dms))
 
-    ProductDiscreteMeasure(DiscreteMeasure.(x, w))
+    return ProductDiscreteMeasure(DiscreteMeasure.(x, w))
 end
 
-function ==(a::T, b::T) where {T<:AbstractDiscreteMeasure}
+function ==(a::T, b::T) where {T <: AbstractDiscreteMeasure}
     n = nfields(a)
-    all(getfield.(Ref(a), 1:n) .== getfield.(Ref(b), 1:n))
+    return all(getfield.(Ref(a), 1:n) .== getfield.(Ref(b), 1:n))
 end
 
-function isapprox(a::T, b::T; kwargs...) where {T<:AbstractDiscreteMeasure}
+function isapprox(a::T, b::T; kwargs...) where {T <: AbstractDiscreteMeasure}
     n = nfields(a)
-    all(isapprox(getfield.(Ref(a), 1:n), getfield.(Ref(b), 1:n); kwargs...))
+    return all(isapprox(getfield.(Ref(a), 1:n), getfield.(Ref(b), 1:n); kwargs...))
 end
 
 

--- a/DiscreteMeasures.jl/src/utils.jl
+++ b/DiscreteMeasures.jl/src/utils.jl
@@ -4,7 +4,7 @@
 Restrict, or clamp the value of `x` to the specified upper and lower bounds `lb` and `ub`, respectively.
 """
 function clamp_domain(x::T, lb, ub) where {T}
-    ifelse(lb ≤ x ≤ ub, x, ifelse(x < lb, T(lb), ifelse(x > ub, T(ub), x)))
+    return ifelse(lb ≤ x ≤ ub, x, ifelse(x < lb, T(lb), ifelse(x > ub, T(ub), x)))
 end
 
 
@@ -15,7 +15,7 @@ Clamp the value of the weight `w` between `0` and `maxw`
 """
 function clamp_weight(w::T, maxw::T = one(T)) where {T}
     @assert maxw > 0
-    clamp_domain(w, zero(T), maxw)
+    return clamp_domain(w, zero(T), maxw)
 end
 
 """ 
@@ -30,11 +30,11 @@ Computes the expected value of the function f with respect to the discrete measu
 function expectation(f, μ::AbstractDiscreteMeasure, send_support_index::Bool = false)
     if send_support_index
         return mapreduce(+, enumerate(support(μ)), weights(μ)) do (i, x), w
-            w*f(x, i)
+            w * f(x, i)
         end
     else
         return mapreduce(+, support(μ), weights(μ)) do x, w
-            w*f(x)
+            w * f(x)
         end
     end
 end
@@ -49,8 +49,8 @@ Utility for combining the support points and weights of independent discrete mea
 - `w`: Iterable of iterables representing the weights for each marginal
 """
 function _product_measure(x, w)
-    X = vec(map(x->vcat(x...), Iterators.product(x...)))
+    X = vec(map(x -> vcat(x...), Iterators.product(x...)))
     W = vec(map(prod, Iterators.product(w...)))
 
-    X, W
+    return X, W
 end

--- a/DiscreteMeasures.jl/test/runtests.jl
+++ b/DiscreteMeasures.jl/test/runtests.jl
@@ -27,7 +27,7 @@ end
     pdms = ProductDiscreteMeasure(dms)
     @test marginals(pdms) == dms
     @test support(pdms) == vec([[a, b] for a in first(x), b in last(x)])
-    @test weights(pdms) == vec([a*b for a in first(w), b in last(w)])
+    @test weights(pdms) == vec([a * b for a in first(w), b in last(w)])
 
     x2 = [-1.0, -2.0]
     w2 = [100.0, 200.0]
@@ -36,21 +36,21 @@ end
     pdms2 = ProductDiscreteMeasure(pdms, dm2)
     @test marginals(pdms2) == [dms; dm2]
     @test support(pdms2) == vec([[a, b, c] for a in first(x), b in last(x), c in x2])
-    @test weights(pdms2) == vec([a*b*c for a in first(w), b in last(w), c in w2])
+    @test weights(pdms2) == vec([a * b * c for a in first(w), b in last(w), c in w2])
 
     pdms3 = ProductDiscreteMeasure(pdms, dms)
     @test marginals(pdms3) == [dms; dms]
     @test support(pdms3) ==
-          vec([[a, b, c, d] for a in first(x), b in last(x), c in first(x), d in last(x)])
+        vec([[a, b, c, d] for a in first(x), b in last(x), c in first(x), d in last(x)])
     @test weights(pdms3) ==
-          vec([a*b*c*d for a in first(w), b in last(w), c in first(w), d in last(w)])
+        vec([a * b * c * d for a in first(w), b in last(w), c in first(w), d in last(w)])
 
     dm1d = DiscreteMeasure(first(x), first(w))
     dm3d = DiscreteMeasure(x, w3d)
     pdms = ProductDiscreteMeasure([dm3d, dm1d])
     @test marginals(pdms) == [dm3d; dm1d]
     @test support(pdms) == vec([vcat(a, b) for a in support(dm3d), b in support(dm1d)])
-    @test weights(pdms) == vec([a*b for a in weights(dm3d), b in weights(dm1d)])
+    @test weights(pdms) == vec([a * b for a in weights(dm3d), b in weights(dm1d)])
 
     @testset "Product of single DiscreteMeasure" begin
         dm = DiscreteMeasure(x, w3d)

--- a/OUQBase.jl/src/OUQBase.jl
+++ b/OUQBase.jl/src/OUQBase.jl
@@ -10,12 +10,12 @@ using CanonicalMoments
 import CanonicalMoments: RawMomentSequence
 
 using Reexport
-# User should not have to depend on CanonicalMoments to use OUQBase. 
+# User should not have to depend on CanonicalMoments to use OUQBase.
 @reexport using CanonicalMoments:
     PolyRootsSupportAlg, PolyWeightAlg, EigvalSupportAlg, EigvecWeightAlg
 
-export 𝔼, ℙ#, 𝟙
-export 𝔼_, ℙ#_, 𝟙_ # for nicer printing 
+export 𝔼, ℙ #, 𝟙
+export 𝔼_, ℙ #_, 𝟙_ # for nicer printing
 include("operators.jl")
 
 
@@ -29,7 +29,7 @@ include("interface.jl")
 include("reduction_transformations/discrete_measures.jl")
 include("reduction_transformations/winkler_extremal_measures.jl")
 
-# Canonical Moments methods: 
+# Canonical Moments methods:
 include("reduction_transformations/canonical_moments.jl")
 
 end

--- a/OUQBase.jl/src/interface.jl
+++ b/OUQBase.jl/src/interface.jl
@@ -10,7 +10,7 @@ macro random_variables(block)
         expansions.args,
         :(
             local group_names_dict =
-                OUQBase.OrderedCollections.OrderedDict{Symbol,Union{Num,Vector{Num}}}()
+                OUQBase.OrderedCollections.OrderedDict{Symbol, Union{Num, Vector{Num}}}()
         ),
     )
     for line in lines
@@ -24,7 +24,7 @@ end
 
 function _build_independent_expr(line::Expr)
     @debug "line: $line"
-    # Single variable case: 
+    # Single variable case:
     var_names = line.args[2]
     if var_names isa Symbol
         @assert length(line.args) == 3 && line.args[3].args[1] == :bounds "Bounds must be specified for each variable"
@@ -45,12 +45,14 @@ function _build_independent_expr(line::Expr)
             var_bounds = line.args[3].args[2].args[i]
             push!(
                 pushes_exprs,
-                :(push!(
-                    var_group,
-                    first(
-                        $(esc(:(Symbolics.@variables $var_name, [bounds = $var_bounds]))),
-                    ),
-                )),
+                :(
+                    push!(
+                        var_group,
+                        first(
+                            $(esc(:(Symbolics.@variables $var_name, [bounds = $var_bounds]))),
+                        ),
+                    )
+                ),
             )
         end
         return quote
@@ -63,52 +65,52 @@ end
 
 abstract type AbstractAdmissibleSet end
 struct AdmissibleSet <: AbstractAdmissibleSet
-    random_variable_map::OrderedDict{Symbol,Union{Num,Vector{Num}}}
-    constraints::Vector{Union{Equation,Inequality}}# A: Yes, all constraints are accepted here. QN: Are constraints containing multiple random variables allowed?
+    random_variable_map::OrderedDict{Symbol, Union{Num, Vector{Num}}}
+    constraints::Vector{Union{Equation, Inequality}} # A: Yes, all constraints are accepted here. QN: Are constraints containing multiple random variables allowed?
 end
 
 function Base.show(io::IO, a::AdmissibleSet)
     println("Random Variables: ", values(a.random_variable_map))
     println("Information Constraints:")
-    display(a.constraints)
+    return display(a.constraints)
 end
 
 abstract type AbstractReductionAlgorithm end
 # Subtypes of AbstractReductionAlgorithm are duck typed
 
 struct WinklerExtremalMeasures <: AbstractReductionAlgorithm
-    constraints_map::OrderedDict{Symbol,Vector{Union{Equation,Inequality}}}
+    constraints_map::OrderedDict{Symbol, Vector{Union{Equation, Inequality}}}
     function WinklerExtremalMeasures(;
-        constraints_map = OrderedDict{Symbol,Vector{Union{Equation,Inequality}}}(),
-    )
-        new(constraints_map)
+            constraints_map = OrderedDict{Symbol, Vector{Union{Equation, Inequality}}}(),
+        )
+        return new(constraints_map)
     end
 end
 
 struct StengerCanonicalMoments <: AbstractReductionAlgorithm
-    constraints_map::OrderedDict{Symbol,Vector{Union{Equation,Inequality}}}
-    raw_moments_map::OrderedDict{Symbol,RawMomentSequence}
-    p_free_map::OrderedDict{Symbol,Vector{Num}}
+    constraints_map::OrderedDict{Symbol, Vector{Union{Equation, Inequality}}}
+    raw_moments_map::OrderedDict{Symbol, RawMomentSequence}
+    p_free_map::OrderedDict{Symbol, Vector{Num}}
     support_alg::CanonicalMoments.AbstractSupportAlg
     weight_alg::CanonicalMoments.AbstractWeightAlg
     function StengerCanonicalMoments(;
-        constraints_map = OrderedDict{Symbol,Vector{Union{Equation,Inequality}}}(),
-        raw_moments_map = OrderedDict{Symbol,RawMomentSequence}(),
-        p_free_map = OrderedDict{Symbol,Vector{Num}}(),
-        support_alg = EigvalSupportAlg(),
-        weight_alg = EigvecWeightAlg(),
-    )
-        new(constraints_map, raw_moments_map, p_free_map, support_alg, weight_alg)
+            constraints_map = OrderedDict{Symbol, Vector{Union{Equation, Inequality}}}(),
+            raw_moments_map = OrderedDict{Symbol, RawMomentSequence}(),
+            p_free_map = OrderedDict{Symbol, Vector{Num}}(),
+            support_alg = EigvalSupportAlg(),
+            weight_alg = EigvecWeightAlg(),
+        )
+        return new(constraints_map, raw_moments_map, p_free_map, support_alg, weight_alg)
     end
 end
 
 function ReductionData(
-    admissible_set::AdmissibleSet,
-    reduction_alg::StengerCanonicalMoments,
-)
+        admissible_set::AdmissibleSet,
+        reduction_alg::StengerCanonicalMoments,
+    )
     constraints_map, raw_moments_map, p_free_map =
         create_canonical_moment_maps(admissible_set, reduction_alg)
-    StengerCanonicalMoments(;
+    return StengerCanonicalMoments(;
         constraints_map,
         raw_moments_map,
         p_free_map,
@@ -118,11 +120,11 @@ function ReductionData(
 end
 
 function ReductionData(
-    admissible_set::AdmissibleSet,
-    reduction_alg::WinklerExtremalMeasures,
-)
+        admissible_set::AdmissibleSet,
+        reduction_alg::WinklerExtremalMeasures,
+    )
     constraints_map = create_constraints_map(admissible_set)
-    WinklerExtremalMeasures(; constraints_map)
+    return WinklerExtremalMeasures(; constraints_map)
 end
 
 abstract type ObjectiveType end
@@ -133,7 +135,7 @@ struct ProbabilityObjective <: ObjectiveType
     _obj::BasicSymbolic
 end
 
-function process_objective(objective::Union{Num,SymbolicUtils.BasicSymbolic})
+function process_objective(objective::Union{Num, SymbolicUtils.BasicSymbolic})
     if objective isa BasicSymbolic && objective.f isa ℙ_
         return ProbabilityObjective(objective)
     else
@@ -142,20 +144,20 @@ function process_objective(objective::Union{Num,SymbolicUtils.BasicSymbolic})
 end
 
 abstract type AbstractOUQSystem end
-struct OUQSystem{A<:ObjectiveType,B<:AbstractReductionAlgorithm,P} <: AbstractOUQSystem
+struct OUQSystem{A <: ObjectiveType, B <: AbstractReductionAlgorithm, P} <: AbstractOUQSystem
     objective::A
     admissible_set::AdmissibleSet
     reduction_data::B
     parameters::P
     function OUQSystem(;
-        objective,
-        admissible_set,
-        reduction_alg::B,
-        parameters = SciMLBase.NullParameters(),
-    ) where {B}
-        reduction_data = ReductionData(admissible_set, reduction_alg) # Note: reduction_data is the populated reduction_alg. 
+            objective,
+            admissible_set,
+            reduction_alg::B,
+            parameters = SciMLBase.NullParameters(),
+        ) where {B}
+        reduction_data = ReductionData(admissible_set, reduction_alg) # Note: reduction_data is the populated reduction_alg.
         objective = process_objective(objective)
-        new{typeof(objective),B,typeof(parameters)}(
+        return new{typeof(objective), B, typeof(parameters)}(
             objective,
             admissible_set,
             reduction_data,
@@ -188,11 +190,11 @@ function get_group_name(var, ouq_sys::OUQSystem)
 end
 
 function get_ordered_group_names(
-    expression,
-    admissible_set::AdmissibleSet;
-    ensure_singleton = true,
-    ensure_all = false,
-)
+        expression,
+        admissible_set::AdmissibleSet;
+        ensure_singleton = true,
+        ensure_all = false,
+    )
     if ensure_singleton
         vars = get_variables(expression)
         @assert length(vars) == 1 "Expression $expression has multiple random variables $vars. Disable `ensure_singleton` if this is intended."
@@ -210,7 +212,7 @@ function get_ordered_group_names(
         else
             return [
                 _group_name for _group_name in keys(admissible_set.random_variable_map) if
-                _group_name in unordered_group_names
+                    _group_name in unordered_group_names
             ]
         end
     end
@@ -223,11 +225,11 @@ The order should be the same as that of `ouq_sys.admissible_set.random_variable_
 - `ensure_all`: If true, the expression is expected to depend on all the random variables in the admissible set and the output is a vector of the same length as `ouq_sys.admissible_set.random_variable_map`. 
 """
 function get_ordered_group_names(
-    expression,
-    ouq_sys::OUQSystem;
-    ensure_singleton = true,
-    ensure_all = false,
-)
+        expression,
+        ouq_sys::OUQSystem;
+        ensure_singleton = true,
+        ensure_all = false,
+    )
     return get_ordered_group_names(
         expression,
         ouq_sys.admissible_set;
@@ -239,8 +241,8 @@ end
 # Contains the reduced OUQ Problem
 abstract type AbstractOUQProblem end
 struct OUQProblem <: AbstractOUQProblem
-    optim_model::Union{OptimizationProblem,JuMP.GenericModel{Float64}}
-    debug_info::Dict{Symbol,Any}
+    optim_model::Union{OptimizationProblem, JuMP.GenericModel{Float64}}
+    debug_info::Dict{Symbol, Any}
 end
 
 abstract type AbstractOptimizationLanguage end
@@ -252,12 +254,12 @@ struct Oracle <: OracleOrSymbolic end
 struct Symbolic <: OracleOrSymbolic end
 
 function OUQProblem(
-    ouq_sys::OUQSystem,
-    optimization_language::AbstractOptimizationLanguage,
-    oracle_or_symbolic::OracleOrSymbolic;
-    parammap = SciMLBase.NullParameters(),
-    kwargs...,
-)
+        ouq_sys::OUQSystem,
+        optimization_language::AbstractOptimizationLanguage,
+        oracle_or_symbolic::OracleOrSymbolic;
+        parammap = SciMLBase.NullParameters(),
+        kwargs...,
+    )
     optim_model, debug_info = construct_optimization_problem(
         ouq_sys,
         parammap,
@@ -265,7 +267,7 @@ function OUQProblem(
         oracle_or_symbolic;
         kwargs...,
     )
-    OUQProblem(optim_model, debug_info)
+    return OUQProblem(optim_model, debug_info)
 end
 
 """
@@ -280,30 +282,32 @@ If the expression is composed of multiple random variables, this is the joint la
 - `ensure_singleton`: If true, the expression is expected to depend on a single random variable and the output is a vector of length 1. 
 - `ensure_all`: If true, the expression is expected to depend on all the random variables in the admissible set and the output is a vector of the same length as `ouq_sys.admissible_set.random_variable_map`. 
 The Lebesgue integral of the expression is taken with respect to this `induced_discrete_measure`.
-""" # Only symbolic because oracle form needs more performant version. 
+""" # Only symbolic because oracle form needs more performant version.
 function process_expression(
-    expression,
-    ouq_sys::OUQSystem,
-    discrete_measure_map::OrderedDict{Symbol,DiscreteMeasure},
-    ::Symbolic;
-    ensure_singleton = false,
-    ensure_all = false,
-)
+        expression,
+        ouq_sys::OUQSystem,
+        discrete_measure_map::OrderedDict{Symbol, DiscreteMeasure},
+        ::Symbolic;
+        ensure_singleton = false,
+        ensure_all = false,
+    )
     @debug "Processing expression: $expression"
     group_names = get_ordered_group_names(expression, ouq_sys; ensure_singleton, ensure_all)
-    # Since group_names is ordered constituent random variables is also ordered. 
+    # Since group_names is ordered constituent random variables is also ordered.
     constituent_random_variables = reduce(
         vcat,
         ouq_sys.admissible_set.random_variable_map[group_name] for
-        group_name in group_names
+            group_name in group_names
     )
     @debug "Constituent random variables: $constituent_random_variables"
     if length(group_names) == 1 # Single random variable
         induced_discrete_measure = discrete_measure_map[only(group_names)]
     else # Multiple random variables
-        induced_discrete_measure = ProductDiscreteMeasure([
-            discrete_measure_map[_group_name] for _group_name in group_names
-        ])
+        induced_discrete_measure = ProductDiscreteMeasure(
+            [
+                discrete_measure_map[_group_name] for _group_name in group_names
+            ]
+        )
     end
     return group_names, constituent_random_variables, induced_discrete_measure
 end
@@ -316,16 +320,16 @@ function extract_decision_vars(_discrete_measure_map)
     _weights_vars = reduce(vcat, get_variables.(reduce(vcat, _weights; init = Num[])))
     _supports_vars = reduce(vcat, get_variables.(reduce(vcat, _supports; init = Num[])))
     # Should be `Num`s not `BasicSymbolic`s
-    wrap.(unique(vcat(_weights_vars, _supports_vars)))
+    return wrap.(unique(vcat(_weights_vars, _supports_vars)))
 end
 
-# Note: This only works for discrete measures not product discrete measures. 
+# Note: This only works for discrete measures not product discrete measures.
 function map_weights_supports_to_canonical_moments(
-    discrete_measure_winkler,
-    discrete_measure_cm,
-)
+        discrete_measure_winkler,
+        discrete_measure_cm,
+    )
     @assert isa(discrete_measure_winkler, DiscreteMeasure) &&
-            isa(discrete_measure_cm, DiscreteMeasure) "This function only works for discrete measures not product discrete measures."
+        isa(discrete_measure_cm, DiscreteMeasure) "This function only works for discrete measures not product discrete measures."
     weights_supports_dict = Dict(
         reduce(vcat, [discrete_measure_winkler.w, discrete_measure_winkler.x]) .=>
             reduce(vcat, [discrete_measure_cm.w, discrete_measure_cm.x]),

--- a/OUQBase.jl/src/reduction_transformations/canonical_moments.jl
+++ b/OUQBase.jl/src/reduction_transformations/canonical_moments.jl
@@ -9,7 +9,7 @@ import CanonicalMoments: RawMomentSequence
 using SciMLBase
 
 
-function get_raw_moment_order(equation::Union{Equation,Inequality}, random_var::Num)
+function get_raw_moment_order(equation::Union{Equation, Inequality}, random_var::Num)
     remove_expectation_rule = @rule 𝔼(~f) => ~f
     extract_moment_rule = @rule ^(~base, ~exponent) => ~exponent
     combined_rule = Chain([remove_expectation_rule, extract_moment_rule])
@@ -27,9 +27,9 @@ function get_raw_moment_order(equation::Union{Equation,Inequality}, random_var::
 end
 
 function CanonicalMoments.RawMomentSequence(
-    random_var::Num,
-    constraints::Vector{Union{Equation,Inequality}},
-)
+        random_var::Num,
+        constraints::Vector{Union{Equation, Inequality}},
+    )
     num_group_cons = length(constraints)
     raw_moment_sequence = fill(NaN, num_group_cons)
     for (i, constraint) in enumerate(constraints)
@@ -41,8 +41,8 @@ function CanonicalMoments.RawMomentSequence(
 end
 
 function create_raw_moments_map(admissible_set::AbstractAdmissibleSet)
-    constraints_map = create_constraints_map(admissible_set)# Reuse existing? 
-    raw_moments_map = OrderedDict{Symbol,RawMomentSequence}()
+    constraints_map = create_constraints_map(admissible_set) # Reuse existing?
+    raw_moments_map = OrderedDict{Symbol, RawMomentSequence}()
     for (k, v) in constraints_map
         length(admissible_set.random_variable_map[k]) == 1 ||
             error("Group is not independent, cannot use canonical moments")
@@ -53,10 +53,10 @@ function create_raw_moments_map(admissible_set::AbstractAdmissibleSet)
 end
 
 # This creates the optimization decision variables for the canonical moment problem.
-# Some code repetition with create_discrete_measure but keeping both makes sense because of the need to provide correct bounds for supports in discrete_measure case.  
+# Some code repetition with create_discrete_measure but keeping both makes sense because of the need to provide correct bounds for supports in discrete_measure case.
 function create_free_variable_vec(group_name::Symbol, n_supports::Int64)
     p_frees = Num[]
-    for i = 1:n_supports
+    for i in 1:n_supports
         p_free_name = Symbol(:p_free, group_name, :_, i)
         push!(p_frees, only(Symbolics.@variables $p_free_name, [bounds = (0.0, 1.0)]))
     end
@@ -71,12 +71,12 @@ Single function to return all 4 maps:
 - transformed_discrete_measure_map::OrderedDict{Symbol, DiscreteMeasures.DiscreteMeasure}. Maps group to (transformed) discrete measure, where the weights and supports are a function of the free decision variables. 
 """
 function create_canonical_moment_maps(
-    admissible_set::AbstractAdmissibleSet,
-    reduction_alg::StengerCanonicalMoments,
-)
+        admissible_set::AbstractAdmissibleSet,
+        reduction_alg::StengerCanonicalMoments,
+    )
     constraints_map = create_constraints_map(admissible_set)
     raw_moments_map = create_raw_moments_map(admissible_set)
-    p_free_map = OrderedDict{Symbol,Vector{Num}}()
+    p_free_map = OrderedDict{Symbol, Vector{Num}}()
     for (k, v) in constraints_map
         n_supports = length(v) + 1
         @debug "Creating a free decision variable vector for $k of length $n_supports"
@@ -88,11 +88,11 @@ function create_canonical_moment_maps(
 end
 
 function discrete_measure_map(
-    ouq_sys::OUQSystem,
-    reduction_alg::StengerCanonicalMoments,
-    ::Symbolic,
-)
-    transformed_discrete_measure_map = OrderedDict{Symbol,DiscreteMeasure}()
+        ouq_sys::OUQSystem,
+        reduction_alg::StengerCanonicalMoments,
+        ::Symbolic,
+    )
+    transformed_discrete_measure_map = OrderedDict{Symbol, DiscreteMeasure}()
     _raw_moments_map = raw_moments_map(ouq_sys)
     _p_free_map = p_free_map(ouq_sys)
     for (k, v) in constraints_map(ouq_sys)
@@ -107,15 +107,15 @@ function discrete_measure_map(
 end
 
 function construct_optimization_problem(
-    ouq_sys::OUQSystem{ExpectationObjective,StengerCanonicalMoments},
-    parammap,
-    ::OptimizationModel,
-    oracle_or_symbolic::Symbolic;
-    kwargs...,
-)
+        ouq_sys::OUQSystem{ExpectationObjective, StengerCanonicalMoments},
+        parammap,
+        ::OptimizationModel,
+        oracle_or_symbolic::Symbolic;
+        kwargs...,
+    )
     objective = ouq_sys.objective
     p_frees_vec = reduce(vcat, values(p_free_map(ouq_sys)))
-    # Somewhat repetitive code: 
+    # Somewhat repetitive code:
     @debug "Objective: $objective._obj"
 
     _discrete_measure_map =
@@ -123,20 +123,20 @@ function construct_optimization_problem(
 
     group_names, constituent_random_variables, induced_discrete_measure =
         process_expression(
-            objective._obj,
-            ouq_sys,
-            _discrete_measure_map,
-            oracle_or_symbolic;
-            ensure_singleton = false,
-            ensure_all = true,
-        )
+        objective._obj,
+        ouq_sys,
+        _discrete_measure_map,
+        oracle_or_symbolic;
+        ensure_singleton = false,
+        ensure_all = true,
+    )
     group_name = Symbol(group_names...)
     @debug "Group names: $group_names"
     @debug "Constituent random variables: $constituent_random_variables"
 
     expectation_rule = @rule 𝔼(~f) => expectation(
         (single_support) ->
-            substitute(~f, Dict(constituent_random_variables .=> single_support)),
+        substitute(~f, Dict(constituent_random_variables .=> single_support)),
         induced_discrete_measure,
     )
     reduced_objective = Symbolics.simplify(objective._obj; rewriter = expectation_rule)
@@ -145,7 +145,7 @@ function construct_optimization_problem(
         OptimizationSystem(reduced_objective, p_frees_vec, ouq_sys.parameters; kwargs...)
     sys = structural_simplify(opt_sys)
     u0_map = map(
-        v -> 0.5*(ModelingToolkit.getbounds(v)[1] .+ ModelingToolkit.getbounds(v)[2]),
+        v -> 0.5 * (ModelingToolkit.getbounds(v)[1] .+ ModelingToolkit.getbounds(v)[2]),
         unknowns(sys),
     )
     debug_info = Dict(
@@ -160,27 +160,27 @@ function construct_optimization_problem(
 end
 
 function construct_optimization_problem(
-    ouq_sys::OUQSystem{<:ProbabilityObjective,StengerCanonicalMoments},
-    parammap,
-    ::OptimizationModel,
-    ::Symbolic;
-    kwargs...,
-)
-    @error "Probability case not implemented yet"
-    # This was not very promising, so probably wont do it. 
+        ouq_sys::OUQSystem{<:ProbabilityObjective, StengerCanonicalMoments},
+        parammap,
+        ::OptimizationModel,
+        ::Symbolic;
+        kwargs...,
+    )
+    return @error "Probability case not implemented yet"
+    # This was not very promising, so probably wont do it.
 end
 
 function construct_optimization_problem(
-    ouq_sys::OUQSystem{
-        <:Union{ProbabilityObjective,ExpectationObjective},
-        StengerCanonicalMoments,
-    },
-    parammap,
-    ::OptimizationModel,
-    ::Oracle;
-    adtype::AbstractADType = SciMLBase.NoAD(),
-    kwargs...,
-)
+        ouq_sys::OUQSystem{
+            <:Union{ProbabilityObjective, ExpectationObjective},
+            StengerCanonicalMoments,
+        },
+        parammap,
+        ::OptimizationModel,
+        ::Oracle;
+        adtype::AbstractADType = SciMLBase.NoAD(),
+        kwargs...,
+    )
     _raw_moments_map = raw_moments_map(ouq_sys)
     _p_free_map = p_free_map(ouq_sys)
     _p_frees_vec = reduce(vcat, values(_p_free_map))
@@ -190,8 +190,8 @@ function construct_optimization_problem(
     # Note: The parammap substitution is written for efficiency and does not fully follow the spirit of OptimizationProblem.
     # The idea is by the time we get here, we assume the parammap is already final
     # So I substitute it right away, so OptimizationProblem does not know there are parameters.
-    # This is only for the oracle case. 
-    # And we only have the oracle case for canonical moments. 
+    # This is only for the oracle case.
+    # And we only have the oracle case for canonical moments.
     paramsdefs_map = Dict(k => ModelingToolkit.getdefault(k) for k in ouq_sys.parameters)
     if !isa(parammap, SciMLBase.NullParameters)
         parammap = merge(paramsdefs_map, parammap)
@@ -221,7 +221,7 @@ function construct_optimization_problem(
     constituent_random_variables = reduce(
         vcat,
         ouq_sys.admissible_set.random_variable_map[group_name] for
-        group_name in group_names
+            group_name in group_names
     )
     num_groups = length(group_names)
     num_groups == length(keys(_raw_moments_map)) ||
@@ -232,7 +232,7 @@ function construct_optimization_problem(
     else
         induced_discrete_measure_func =
             (discrete_measure_vec) ->
-                ProductDiscreteMeasure([discrete_measure_vec[i] for i = 1:num_groups])
+        ProductDiscreteMeasure([discrete_measure_vec[i] for i in 1:num_groups])
     end
 
     group_num_decision_vars = map(length, values(_p_free_map))
@@ -240,19 +240,19 @@ function construct_optimization_problem(
     if all(x -> x == group_num_decision_vars[1], group_num_decision_vars) # All groups have the same number of constraints and decision variables, formulate a matrix
         partition =
             (p_frees_cand) -> transpose(
-                reshape(
-                    p_frees_cand,
-                    group_num_decision_vars[1],
-                    length(group_num_decision_vars),
-                ),
-            )
+            reshape(
+                p_frees_cand,
+                group_num_decision_vars[1],
+                length(group_num_decision_vars),
+            ),
+        )
     else
         error("This is most likely implemented incorrectly")
         partition =
             (p_frees_cand) -> [
-                view(p_frees_cand, 1:cumsum(group_num_decision_vars)[i]) for
-                i = 1:length(group_num_decision_vars)
-            ] # else, formulate a vector of vectors
+            view(p_frees_cand, 1:cumsum(group_num_decision_vars)[i]) for
+                i in 1:length(group_num_decision_vars)
+        ] # else, formulate a vector of vectors
         @warn "Not well tested"
     end
 
@@ -262,14 +262,14 @@ function construct_optimization_problem(
         # TODO: Dispatch on Probability Function approximation here.
         ouq_obj_f =
             (rand_var_vec) -> Symbolics.evaluate(
-                condition,
-                Dict(constituent_random_variables .=> rand_var_vec),
-            )
+            condition,
+            Dict(constituent_random_variables .=> rand_var_vec),
+        )
     elseif isa(ouq_sys.objective, ExpectationObjective)
         #expectation_rule = @rule 𝔼(~f) => expectation((single_support) -> substitute(~f, Dict(constituent_random_variables .=> single_support)), discrete_measure)
         extract_f_rule = @rule 𝔼(~f) =>
             (rand_var_vec) ->
-                substitute(~f, Dict(constituent_random_variables .=> rand_var_vec))
+        substitute(~f, Dict(constituent_random_variables .=> rand_var_vec))
         # QN: Will variables always be passed in right order? Should be correct since this order is preserved in getting the induced_discrete_measure.
         ouq_obj_f = simplify(obj_expression; rewriter = extract_f_rule)
     else
@@ -277,15 +277,15 @@ function construct_optimization_problem(
     end
 
 
-    # Closure for objective function: 
-    function objective_f(p_frees_cand, ps) # Functions may be faster than higher order functions    
+    # Closure for objective function:
+    function objective_f(p_frees_cand, ps) # Functions may be faster than higher order functions
         _partitioned_p_frees = partition(p_frees_cand)
         _discrete_measure_vec = [
             f(row) for
-            (f, row) in zip(transform_functors_vec, eachrow(_partitioned_p_frees))
+                (f, row) in zip(transform_functors_vec, eachrow(_partitioned_p_frees))
         ]
         _joint_law_pdm = induced_discrete_measure_func(_discrete_measure_vec)
-        expectation(ouq_obj_f, _joint_law_pdm)
+        return expectation(ouq_obj_f, _joint_law_pdm)
     end
 
     opt_f = OptimizationFunction(objective_f, adtype; kwargs...)
@@ -297,7 +297,7 @@ function construct_optimization_problem(
         ub = ones(total_num_decision_vars),
         kwargs...,
     )
-    debug_info = Dict{Symbol,Any}(
+    debug_info = Dict{Symbol, Any}(
         :objective_f => objective_f,
         :decision_vars => _p_frees_vec,
         :decision_vars_cand => _p_frees_cand,
@@ -308,15 +308,15 @@ function construct_optimization_problem(
 end
 
 function construct_optimization_problem(
-    ouq_sys::OUQSystem{
-        <:Union{ProbabilityObjective,ExpectationObjective},
-        StengerCanonicalMoments,
-    },
-    parammap,
-    ::JuMPModel,
-    oracle_or_symbolic::Symbolic;
-    kwargs...,
-)
+        ouq_sys::OUQSystem{
+            <:Union{ProbabilityObjective, ExpectationObjective},
+            StengerCanonicalMoments,
+        },
+        parammap,
+        ::JuMPModel,
+        oracle_or_symbolic::Symbolic;
+        kwargs...,
+    )
     if !isa(parammap, SciMLBase.NullParameters)
         error("Parameter map not supported for JuMPModel")
     end
@@ -326,7 +326,7 @@ function construct_optimization_problem(
     _symbolic_decision_vars = extract_decision_vars(_discrete_measure_map)
     optim_to_jump_dict = add_optim_vars!(optim_model, _symbolic_decision_vars)
 
-    # Use the Winkler methods: 
+    # Use the Winkler methods:
     (; induced_discrete_measure, reduced_objective) = convert_objective!(
         optim_model,
         ouq_sys,

--- a/OUQBase.jl/src/reduction_transformations/discrete_measures.jl
+++ b/OUQBase.jl/src/reduction_transformations/discrete_measures.jl
@@ -1,15 +1,15 @@
 # Creates a 1D DiscreteMeasure (dispatches on Num vs Vector{Num}) with `n_supports` supports. The supports `x` and weights `w` are vectors of symbolic variables.
 function create_discrete_measure(
-    group_name::Symbol,
-    random_variable::Num,
-    n_supports::Int64,
-)
+        group_name::Symbol,
+        random_variable::Num,
+        n_supports::Int64,
+    )
     supports = Num[]
     weights = Num[]
 
-    # Don't use symbolic arrays! 
-    # Each of these is a vector of vectors 
-    for i = 1:n_supports
+    # Don't use symbolic arrays!
+    # Each of these is a vector of vectors
+    for i in 1:n_supports
         weight_name = Symbol(:w, group_name, :_, i)
         support_name = Symbol(:x, group_name, :_, i)
         push!(
@@ -23,15 +23,15 @@ function create_discrete_measure(
 end
 
 function create_discrete_measure(
-    group_name::Symbol,
-    random_variables::Vector{Num},
-    n_supports::Int64,
-)
+        group_name::Symbol,
+        random_variables::Vector{Num},
+        n_supports::Int64,
+    )
     supports = Vector{Num}[]
     weights = Num[]
 
-    # Each of these is a vector of vectors 
-    for i = 1:n_supports
+    # Each of these is a vector of vectors
+    for i in 1:n_supports
         weight_name = Symbol(:w, group_name, :_, i)
         single_supports_vec = Num[]
         for (j, var) in enumerate(random_variables)
@@ -52,8 +52,8 @@ end
 # Currently, each constraint can only be defined in terms of a single random variable.
 function create_constraints_map(admissible_set::AbstractAdmissibleSet) # TODO: rite in terms of map_vars_to_group
     constraints_map = OrderedDict(
-        var => Union{Equation,Inequality}[] for
-        var in keys(admissible_set.random_variable_map)
+        var => Union{Equation, Inequality}[] for
+            var in keys(admissible_set.random_variable_map)
     )
     for c in admissible_set.constraints
         group_names = get_ordered_group_names(
@@ -69,11 +69,11 @@ end
 
 
 function create_discrete_measure_map(
-    admissible_set::AbstractAdmissibleSet,
-    ::WinklerExtremalMeasures,
-)
+        admissible_set::AbstractAdmissibleSet,
+        ::WinklerExtremalMeasures,
+    )
     constraints_map = create_constraints_map(admissible_set)
-    dm_map = OrderedDict{Symbol,DiscreteMeasure}()
+    dm_map = OrderedDict{Symbol, DiscreteMeasure}()
     for (k, v) in constraints_map
         n_supports = length(v) + 1
         @debug "Creating discrete measure for $k with $n_supports supports"
@@ -84,10 +84,10 @@ function create_discrete_measure_map(
 end
 
 function discrete_measure_map(
-    ouq_sys::OUQSystem,
-    reduction_alg::WinklerExtremalMeasures,
-    ::Symbolic,
-)
+        ouq_sys::OUQSystem,
+        reduction_alg::WinklerExtremalMeasures,
+        ::Symbolic,
+    )
     discrete_measure_map =
         create_discrete_measure_map(ouq_sys.admissible_set, reduction_alg)
     return discrete_measure_map
@@ -95,11 +95,11 @@ end
 #ouq_sys.reduction_data isa StengerCanonicalMoments ? ouq_sys.reduction_data.transformed_discrete_measure_map : ouq_sys.reduction_data.discrete_measure_map
 
 function discrete_measure_map(
-    ouq_sys::OUQSystem,
-    reduction_alg::WinklerExtremalMeasures,
-    oracle_or_symbolic::Oracle,
-)
-    @error "Not implemented"
+        ouq_sys::OUQSystem,
+        reduction_alg::WinklerExtremalMeasures,
+        oracle_or_symbolic::Oracle,
+    )
+    return @error "Not implemented"
 end
 
 

--- a/OUQBase.jl/src/reduction_transformations/winkler_extremal_measures.jl
+++ b/OUQBase.jl/src/reduction_transformations/winkler_extremal_measures.jl
@@ -1,10 +1,10 @@
 import Base.Iterators: flatten
 
 function convert_inequality_to_jump_leq_lhs(
-    ineq::Inequality;
-    complement = false,
-    tol = 1e-10,
-)
+        ineq::Inequality;
+        complement = false,
+        tol = 1.0e-10,
+    )
     if ineq.relational_op == Symbolics.leq
         jump_leq_lhs = complement ? ineq.rhs - ineq.lhs + tol : ineq.lhs - ineq.rhs
     elseif ineq.relational_op == Symbolics.geq
@@ -15,7 +15,7 @@ function convert_inequality_to_jump_leq_lhs(
     return jump_leq_lhs
 end
 
-function get_finite_bounds(optim_vars; min_bound = -1e10, max_bound = 1e10)
+function get_finite_bounds(optim_vars; min_bound = -1.0e10, max_bound = 1.0e10)
     all_bounds = getbounds.(optim_vars)
 
     lower_bound = map(x -> x[1] != -Inf ? x[1] : min_bound, all_bounds)
@@ -37,14 +37,14 @@ function add_optim_vars!(optim_model, optim_vars)
 
     jump_vars = @variable(optim_model, [1:length(optim_vars)])
 
-    for i = 1:length(optim_vars)
+    for i in 1:length(optim_vars)
         set_name(jump_vars[i], String(optim_var_names[i]))
         optim_model[optim_var_names[i]] = jump_vars[i]
     end
     set_lower_bound.(jump_vars, lower_bounds)
     set_upper_bound.(jump_vars, upper_bounds)
     optim_to_jump_dict =
-        OrderedDict(optim_vars[i] => jump_vars[i] for i = 1:length(optim_vars))
+        OrderedDict(optim_vars[i] => jump_vars[i] for i in 1:length(optim_vars))
     return optim_to_jump_dict
 end
 
@@ -53,19 +53,19 @@ end
 # 2) right optim_vars_sub
 # Possible other things like dispatch on reduction_algorithm or backen d, but for now it is JuMP and WinklerExtremalMeasures.
 # We can rewrite it using map_vars_to_group.
-# 1D case: 
+# 1D case:
 
 # random_variable:
 
 # consider a test function:
-# f(support_row) -> 
+# f(support_row) ->
 function convert_to_JuMP_constraint!(
-    optim_model,
-    constraint::Union{Equation,Inequality},
-    discrete_measure::Union{DiscreteMeasure,ProductDiscreteMeasure},
-    random_variable_group::Union{Num,Vector{Num}},
-    optim_to_jump_dict,
-)
+        optim_model,
+        constraint::Union{Equation, Inequality},
+        discrete_measure::Union{DiscreteMeasure, ProductDiscreteMeasure},
+        random_variable_group::Union{Num, Vector{Num}},
+        optim_to_jump_dict,
+    )
     @debug "Original constraint: $constraint"
     @debug "Random variable group: $random_variable_group"
     # Note: (args) below will the decision_variable corresponding to each support point (which may be multi-dimension for the dependent group case). WILL THIS WORK?
@@ -75,7 +75,7 @@ function convert_to_JuMP_constraint!(
     )
     reduced_constraint = Symbolics.simplify(constraint; rewriter = expectation_rule)
     @debug "Symbolics reduced constraint: $reduced_constraint"
-    if isa(reduced_constraint, Equation)
+    return if isa(reduced_constraint, Equation)
         equality_lhs = reduced_constraint.lhs - reduced_constraint.rhs
         jump_constraint_lhs =
             only(map(identity, substitute(equality_lhs, optim_to_jump_dict)))
@@ -89,10 +89,10 @@ function convert_to_JuMP_constraint!(
 end
 
 function add_weight_constraints!(
-    optim_model,
-    discrete_measure::DiscreteMeasure,
-    optim_to_jump_dict,
-)
+        optim_model,
+        discrete_measure::DiscreteMeasure,
+        optim_to_jump_dict,
+    )
     symbolics_constraint = sum(weights(discrete_measure)) ~ 1.0
     @debug "Symbolics weight constraint: $symbolics_constraint"
     symbolics_lhs = symbolics_constraint.lhs - symbolics_constraint.rhs
@@ -103,13 +103,13 @@ function add_weight_constraints!(
 end
 
 function convert_objective!(
-    optim_model,
-    ouq_sys,
-    objective::ProbabilityObjective,
-    oracle_or_symbolic::Symbolic,
-    optim_to_jump_dict,
-)
-    # Currently we only allow one inequality constraint on the probability. TODO: Set constraints e.g., Turret would require two inequalities. 
+        optim_model,
+        ouq_sys,
+        objective::ProbabilityObjective,
+        oracle_or_symbolic::Symbolic,
+        optim_to_jump_dict,
+    )
+    # Currently we only allow one inequality constraint on the probability. TODO: Set constraints e.g., Turret would require two inequalities.
     # Two inequalities would just mean two more constraints per support point (one satisfying and one not satisfying the condition)
     condition = only(arguments(objective._obj))
     @debug "Probability condition: $condition"
@@ -119,13 +119,13 @@ function convert_objective!(
 
     group_names, constituent_random_variables, induced_discrete_measure =
         process_expression(
-            condition,
-            ouq_sys,
-            _discrete_measure_map,
-            oracle_or_symbolic;
-            ensure_singleton = false,
-            ensure_all = true,
-        )
+        condition,
+        ouq_sys,
+        _discrete_measure_map,
+        oracle_or_symbolic;
+        ensure_singleton = false,
+        ensure_all = true,
+    )
     @debug "Group names: $group_names"
     @debug "Constituent variable group: $constituent_random_variables"
 
@@ -137,11 +137,11 @@ function convert_objective!(
     # This function adds one indicator constraint for support point i corresponding to indicator variable jump_on_var
     # It needs to be called twice for each support point, once for the on constraint and once for the off constraint
     function add_indicator_constraint_for_support!(
-        i,
-        jump_on_var,
-        jump_on_var_name;
-        off_constraint = false,
-    )
+            i,
+            jump_on_var,
+            jump_on_var_name;
+            off_constraint = false,
+        )
         cons_var_name = off_constraint ? :_off : :_on
 
         # Having a random_variable_group as Vector{Num} works perfectly
@@ -162,7 +162,7 @@ function convert_objective!(
             ),
         )
 
-        # Issue is that the indicator constraint has to be linear! 
+        # Issue is that the indicator constraint has to be linear!
         jump_constraint_lhs_var = @variable(optim_model)
         jump_constraint_lhs_var_name = Symbol(:in_con, group_name, i, cons_var_name)
         set_name(jump_constraint_lhs_var, String(jump_constraint_lhs_var_name))
@@ -171,7 +171,7 @@ function convert_objective!(
         @constraint(optim_model, jump_constraint_lhs_var == jump_constraint_lhs)
 
         @debug "Jump $(cons_var_name) constraint for $(jump_on_var_name) : $jump_constraint_lhs <= 0.0"
-        if off_constraint
+        return if off_constraint
             @constraint(optim_model, !jump_on_var --> {jump_constraint_lhs_var <= 0.0})
         else
             @constraint(optim_model, jump_on_var --> {jump_constraint_lhs_var <= 0.0})
@@ -179,7 +179,7 @@ function convert_objective!(
     end
 
     @debug "$(ndims(induced_discrete_measure)) dimensional discrete measure with $(DiscreteMeasures.order(induced_discrete_measure)) support points"
-    for i = 1:DiscreteMeasures.order(induced_discrete_measure)
+    for i in 1:DiscreteMeasures.order(induced_discrete_measure)
         # TODO: symbolic_on_var may not be necessary, can directly substitute to JuMP.
         symbolic_on_var_name = Symbol(:on_var, i)
         symbolic_on_var = only(Symbolics.@variables $(symbolic_on_var_name))
@@ -240,12 +240,12 @@ function convert_objective!(
 end
 
 function convert_objective!(
-    optim_model,
-    ouq_sys,
-    objective::ExpectationObjective,
-    oracle_or_symbolic::Symbolic,
-    optim_to_jump_dict,
-)
+        optim_model,
+        ouq_sys,
+        objective::ExpectationObjective,
+        oracle_or_symbolic::Symbolic,
+        optim_to_jump_dict,
+    )
     @debug "Objective: $objective.objective"
 
     _discrete_measure_map =
@@ -253,13 +253,13 @@ function convert_objective!(
 
     group_names, constituent_random_variables, induced_discrete_measure =
         process_expression(
-            objective._obj,
-            ouq_sys,
-            _discrete_measure_map,
-            oracle_or_symbolic;
-            ensure_singleton = false,
-            ensure_all = true,
-        )
+        objective._obj,
+        ouq_sys,
+        _discrete_measure_map,
+        oracle_or_symbolic;
+        ensure_singleton = false,
+        ensure_all = true,
+    )
 
     @debug "Group names: $group_names"
     @debug "Constituent variable group: $constituent_random_variables"
@@ -267,7 +267,7 @@ function convert_objective!(
 
     expectation_rule = @rule 𝔼(~f) => expectation(
         (single_support) ->
-            substitute(~f, Dict(constituent_random_variables .=> single_support)),
+        substitute(~f, Dict(constituent_random_variables .=> single_support)),
         induced_discrete_measure,
     )
     reduced_objective = Symbolics.simplify(objective._obj; rewriter = expectation_rule)
@@ -276,20 +276,20 @@ function convert_objective!(
     jump_objective = substitute(reduced_objective ~ 0.0, optim_to_jump_dict)
     @debug "JuMP objective: $(jump_objective.lhs)"
     @objective(optim_model, Min, jump_objective.lhs)
-    return (; induced_discrete_measure, reduced_objective) # For debugging. 
+    return (; induced_discrete_measure, reduced_objective) # For debugging.
 end
 
-# objective is dispatched on for canonical moment calses. 
+# objective is dispatched on for canonical moment calses.
 function construct_optimization_problem(
-    ouq_sys::OUQSystem{
-        <:Union{ProbabilityObjective,ExpectationObjective},
-        WinklerExtremalMeasures,
-    },
-    parammap,
-    ::JuMPModel,
-    oracle_or_symbolic::Symbolic;
-    kwargs...,
-)
+        ouq_sys::OUQSystem{
+            <:Union{ProbabilityObjective, ExpectationObjective},
+            WinklerExtremalMeasures,
+        },
+        parammap,
+        ::JuMPModel,
+        oracle_or_symbolic::Symbolic;
+        kwargs...,
+    )
     if !isa(parammap, SciMLBase.NullParameters)
         error("Parameter map not supported for JuMPModel")
     end
@@ -297,7 +297,7 @@ function construct_optimization_problem(
     optim_model = JuMP.Model()
     _discrete_measure_map =
         discrete_measure_map(ouq_sys, ouq_sys.reduction_data, Symbolic())
-    # We want flat vectors even in multidimensional DM cases: 
+    # We want flat vectors even in multidimensional DM cases:
     # This may fail if you have a product measure of discrete measures of multiple random varaibles.
     weight_vars, support_vars =
         collect(flatten(flatten(weights.(values(_discrete_measure_map))))),
@@ -347,10 +347,10 @@ function construct_optimization_problem(
 end
 
 function get_reduced_symbolic_constraint(
-    constraint::Union{Equation,Inequality},
-    discrete_measure::Union{DiscreteMeasure,ProductDiscreteMeasure},
-    random_variable_group::Union{Num,Vector{Num}},
-)
+        constraint::Union{Equation, Inequality},
+        discrete_measure::Union{DiscreteMeasure, ProductDiscreteMeasure},
+        random_variable_group::Union{Num, Vector{Num}},
+    )
     @debug "Original constraint: $constraint"
     @debug "Random variable group: $random_variable_group"
 
@@ -364,12 +364,12 @@ function get_reduced_symbolic_constraint(
 end
 
 function construct_optimization_problem(
-    ouq_sys::OUQSystem{<:ProbabilityObjective,WinklerExtremalMeasures},
-    parammap,
-    ::OptimizationModel,
-    oracle_or_symbolic::Symbolic;
-    kwargs...,
-)
+        ouq_sys::OUQSystem{<:ProbabilityObjective, WinklerExtremalMeasures},
+        parammap,
+        ::OptimizationModel,
+        oracle_or_symbolic::Symbolic;
+        kwargs...,
+    )
     @debug "Objective: $objective.objective"
     objective = ouq_sys.objective
     extract_condition_rule = @rule ℙ(~condition) => ~condition
@@ -378,16 +378,16 @@ function construct_optimization_problem(
         discrete_measure_map(ouq_sys, ouq_sys.reduction_data, oracle_or_symbolic)
     group_names, constituent_random_variables, induced_discrete_measure =
         process_expression(
-            condition,
-            ouq_sys,
-            _discrete_measure_map,
-            oracle_or_symbolic;
-            ensure_singleton = false,
-            ensure_all = true,
-        )
+        condition,
+        ouq_sys,
+        _discrete_measure_map,
+        oracle_or_symbolic;
+        ensure_singleton = false,
+        ensure_all = true,
+    )
 
-    ## In the exact case, we are using the Symbolic.evaluate function 
-    # TODO: Dispatch on Probability Function approximation here. 
+    ## In the exact case, we are using the Symbolic.evaluate function
+    # TODO: Dispatch on Probability Function approximation here.
     reduced_objective = expectation(
         (single_support) -> Symbolics.evaluate(
             condition,
@@ -397,9 +397,9 @@ function construct_optimization_problem(
     )
     @debug "Symbolics reduced objective: $reduced_objective"
 
-    # Constraints: 
+    # Constraints:
     _constraints_map = constraints_map(ouq_sys)
-    _reduced_constraints = Equation[] # Currently only equalities. Should extend to Inequalities trivially in symbolics, but JuMP requires more work. 
+    _reduced_constraints = Equation[] # Currently only equalities. Should extend to Inequalities trivially in symbolics, but JuMP requires more work.
     for group_name in keys(_constraints_map)
         @debug "Adding constraints for $group_name"
         for constraint in _constraints_map[group_name]
@@ -414,7 +414,7 @@ function construct_optimization_problem(
         end
     end
 
-    # Weights constraints: 
+    # Weights constraints:
     _weight_constraints = Equation[]
     for group_name in keys(_discrete_measure_map)
         @debug "Adding weight constraints for $group_name"
@@ -425,7 +425,7 @@ function construct_optimization_problem(
 
     _symbolic_decision_vars = extract_decision_vars(_discrete_measure_map)
     u0_map = map(
-        v -> 0.5*(ModelingToolkit.getbounds(v)[1] .+ ModelingToolkit.getbounds(v)[2]),
+        v -> 0.5 * (ModelingToolkit.getbounds(v)[1] .+ ModelingToolkit.getbounds(v)[2]),
         _symbolic_decision_vars,
     )
 

--- a/OUQBase.jl/test/FloodProblem/2D_independent.jl
+++ b/OUQBase.jl/test/FloodProblem/2D_independent.jl
@@ -25,12 +25,12 @@ Zᵥ = 50.0
 
 admissible_set = AdmissibleSet(rand_vars, constraints)
 
-H = (Q/(300*Kₛ*((Zₘ - Zᵥ)/5000)^(0.5)))^(3/5)
+H = (Q / (300 * Kₛ * ((Zₘ - Zᵥ) / 5000)^(0.5)))^(3 / 5)
 
 objective_expectation = 𝔼(H)
 
 
-# Design parameter: 
+# Design parameter:
 pars = @parameters begin
     h = 2.0, [bounds = (2.0, 4.0)]
 end

--- a/OUQBase.jl/test/FloodProblem/Q_only.jl
+++ b/OUQBase.jl/test/FloodProblem/Q_only.jl
@@ -16,12 +16,12 @@ Kₛ = 30.0
 Zₘ = 54.5
 Zᵥ = 50.0
 
-H = (Q/(300*Kₛ*((Zₘ - Zᵥ)/5000)^(0.5)))^(3/5)
+H = (Q / (300 * Kₛ * ((Zₘ - Zᵥ) / 5000)^(0.5)))^(3 / 5)
 
 objective_expectation = 𝔼(H)
 
 
-# Design parameter: 
+# Design parameter:
 pars = @parameters begin
     h = 2.0, [bounds = (2.0, 4.0)]
 end
@@ -99,12 +99,12 @@ isdefined(Main, :probability_canonical_moments_problems_analytic) && push!(
 isdefined(Main, :probability_solutions) &&
     push!(probability_solutions, "Flood Q only" => 0.17)
 
-# Hacky test for now: 
+# Hacky test for now:
 ouq_prob = OUQProblem(ouq_sys_probability_canonical_moments, OptimizationModel(), Oracle())
 sol = solve(
-            ouq_prob.optim_model,
-            BBO_adaptive_de_rand_1_bin_radiuslimited();
-            maxiters = 100,
-            maxtime = 60.0,
-            verbose = true,
-            )
+    ouq_prob.optim_model,
+    BBO_adaptive_de_rand_1_bin_radiuslimited();
+    maxiters = 100,
+    maxtime = 60.0,
+    verbose = true,
+)

--- a/OUQBase.jl/test/FloodProblem/full_dependent.jl
+++ b/OUQBase.jl/test/FloodProblem/full_dependent.jl
@@ -21,8 +21,8 @@ constraints = [
     𝔼(Zₘ) ~ 54.5
     𝔼(Q^2) ~ 2.1632e6
     𝔼(Kₛ^2) ~ 949.137
-    𝔼(Zᵥ^2) ~ 7501.0/3.0
-    𝔼(Zₘ^2) ~ 8911.0/3.0
+    𝔼(Zᵥ^2) ~ 7501.0 / 3.0
+    𝔼(Zₘ^2) ~ 8911.0 / 3.0
     #=     
         𝔼(Q^3) ~ 4.18e9
         𝔼(Kₛ^3) ~ 31422.3
@@ -32,11 +32,11 @@ constraints = [
 
 admissible_set = AdmissibleSet(rand_vars, constraints)
 
-H = (Q/(300*Kₛ*((Zₘ - Zᵥ)/5000)^(0.5)))^(3/5)
+H = (Q / (300 * Kₛ * ((Zₘ - Zᵥ) / 5000)^(0.5)))^(3 / 5)
 
 objective_expectation = 𝔼(H)
 
-# Design parameter: 
+# Design parameter:
 pars = @parameters begin
     h = 2.0, [bounds = (2.0, 4.0)]
 end

--- a/OUQBase.jl/test/FloodProblem/full_independent.jl
+++ b/OUQBase.jl/test/FloodProblem/full_independent.jl
@@ -17,8 +17,8 @@ constraints = [
     𝔼(Zₘ) ~ 54.5
     𝔼(Q^2) ~ 2.1632e6
     𝔼(Kₛ^2) ~ 949.137
-    𝔼(Zᵥ^2) ~ 7501.0/3.0
-    𝔼(Zₘ^2) ~ 8911.0/3.0
+    𝔼(Zᵥ^2) ~ 7501.0 / 3.0
+    𝔼(Zₘ^2) ~ 8911.0 / 3.0
     #=     
         𝔼(Q^3) ~ 4.18e9
         𝔼(Kₛ^3) ~ 31422.3
@@ -28,13 +28,13 @@ constraints = [
 
 admissible_set = AdmissibleSet(rand_vars, constraints)
 
-# NaNMMath: 
-H = (Q/(300*Kₛ*NaNMath.sqrt((Zₘ - Zᵥ)/5000)))^(3/5)
+# NaNMMath:
+H = (Q / (300 * Kₛ * NaNMath.sqrt((Zₘ - Zᵥ) / 5000)))^(3 / 5)
 #H = (Q/(300*Kₛ*((Zₘ - Zᵥ)/5000)^(0.5)))^(3/5)
 
 objective_expectation = 𝔼(H)
 
-# Design parameter: 
+# Design parameter:
 pars = @parameters begin
     h = 2.0, [bounds = (2.0, 4.0)]
 end

--- a/_typos.toml
+++ b/_typos.toml
@@ -1,0 +1,4 @@
+[files]
+# Machine-generated Pluto.jl HTML exports; the only hits are author surnames
+# (e.g. "Fons van der Plas") in embedded boilerplate, not editable prose.
+extend-exclude = ["presentation/*.html"]


### PR DESCRIPTION
Please ignore until reviewed by @ChrisRackauckas.

Normalizes CI toward the Sundials.jl standard set using the centralized reusable workflows in `SciML/.github` (all calls pinned `@v1`). This repo is a Julia `[workspace]` monorepo (root `Project.toml` is a workspace with no package; the three packages live in `CanonicalMoments.jl/`, `DiscreteMeasures.jl/`, `OUQBase.jl/`), so a few standard pieces required adaptation — see Notes/Caveats.

## Workflows

**Converted**
- `Tests.yml` — was a hand-rolled matrix running `Pkg.test("<submodule>")` from the workspace root on Julia `1.12` for the three submodules. Now calls `tests.yml@v1` with a `submodule` × `version` matrix, passing each submodule directory via the `project:` input (`julia-runtest` runs `Pkg.test()` on that project, which resolves the workspace-local deps). `coverage: false` (the original collected no coverage). The original `upload-manifest` job is preserved unchanged. The exact version×submodule matrix (1.12 × {CanonicalMoments.jl, DiscreteMeasures.jl, OUQBase.jl}) is reproduced.

**Added**
- `FormatCheck.yml` — Runic format check via `runic.yml@v1`. This repo did not previously run Runic, so all git-tracked `.jl` files were reformatted in place with Runic v1 and committed. Verified locally that all three submodule test suites still pass on Julia 1.12 after reformatting.
- `SpellCheck.yml` — typos spell check via `spellcheck.yml@v1`.
- `_typos.toml` — minimal exclusion of the machine-generated Pluto HTML exports under `presentation/` (the only hits there are author surnames like "Fons van der Plas" in generated boilerplate).
- `.github/dependabot.yml` — new. `github-actions` (weekly, `/`) and `julia` (daily, grouped `all-julia-packages: ["*"]`) covering every directory that contains a `Project.toml`: `/`, `/CanonicalMoments.jl`, `/CanonicalMoments.jl/docs`, `/CanonicalMoments.jl/examples`, `/CanonicalMoments.jl/test`, `/DiscreteMeasures.jl`, `/DiscreteMeasures.jl/docs`, `/OUQBase.jl`, `/OUQBase.jl/test`.

**Not added (with reasons)**
- **Downgrade** — `downgrade.yml@v1` runs `julia-runtest` with `--project=@.` (the checkout root) and exposes no `project:` input. For this workspace, `Pkg.test()` at the root errors (the root is a workspace, not a package), so a faithful per-submodule downgrade is not expressible via `downgrade.yml@v1`. Omitted rather than adding a guaranteed-red job. Would need a `project:` input added to the reusable downgrade workflow, or a custom matrix workflow.
- **Documentation** — there is no root `docs/make.jl`; docs live in `CanonicalMoments.jl/docs` and `DiscreteMeasures.jl/docs`. `documentation.yml@v1` is hardcoded to `--project=docs/` + `docs/make.jl` at the root and `Pkg.develop(path=pwd())` (the empty workspace module), so it cannot build the per-submodule docs. Those docs are also template stubs (`authors = "TODO"`, `deploydocs` commented out / absent) and there was no documentation workflow before. Omitted.
- **Downstream / Benchmark / QA / TagBot** — none existed and none added.

**Removed**
- CompatHelper — none was present, so nothing to remove. Dependabot's `julia` ecosystem now provides compat automation.

## Typos findings (SpellCheck will be red)
These are real misspellings in source/tests/examples; left for the maintainer to fix (no mass prose edits in this PR):
- `CanonicalMoments.jl/ext/ForwardDiffExt.jl:17` — `denomenator` → `denominator`
- `CanonicalMoments.jl/src/measure_transform_algs.jl:15` — `teh` → `the`
- `CanonicalMoments.jl/src/moment_sequences.jl:140` — `Corrollary` → `Corollary`
- `CanonicalMoments.jl/test/moment_sequence.jl:189` — `Thm` → `Them`
- `CanonicalMoments.jl/examples/1_Stenger_flood.jl:48` — `Contstraint` → `Constraint`
- `CanonicalMoments.jl/examples/multivariate_example.jl:24,25` — `seqences` → `sequences`
- `OUQBase.jl/src/reduction_transformations/winkler_extremal_measures.jl:54,189,301` — `backen` → `backend`, `satisified` → `satisfied`, `varaibles` → `variables`

## Branch protection
Check names change with this migration (e.g. the test jobs now render as "Tests" from the reusable caller). Update the repo's branch-protection required-status-checks accordingly after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)