### PR TITLE
Simplify root CI to grouped-tests.yml (matrix from test/test_groups.toml)

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -16,92 +16,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
 jobs:
-  test:
-    permissions:
-      actions: write
-      contents: read
-    runs-on: ubuntu-latest
-    timeout-minutes: 120
-    env:
-      # Pin the depot path so the registry-refresh step and the subsequent
-      # julia-actions/julia-{buildpkg,runtest} steps all read and write the
-      # same depot on self-hosted runners (where the runner may otherwise
-      # inject ~/github-runners/<name>/.julia for some steps but not others,
-      # causing "expected package X to be registered" failures when General is
-      # refreshed into ~/.julia but resolve happens against the per-runner
-      # depot).
-      JULIA_DEPOT_PATH: ~/.julia
-    strategy:
-      fail-fast: false
-      matrix:
-        group:
-          - Core
-        version:
-          - 'lts'
-          - '1'
-          - 'pre'
-    steps:
-      - uses: actions/checkout@v6
-      - uses: julia-actions/setup-julia@v3
-        with:
-          version: ${{ matrix.version }}
-      # Split cache restore/save by event to work around recurring GitHub
-      # Actions cache upload auth failures (Azure SAS "Server failed to
-      # authenticate the request"). PRs only restore from a recent main push
-      # cache; only main push runs write the cache. continue-on-error keeps a
-      # transient cache backend hiccup from flunking an otherwise green job.
-      - name: Cache Julia depot (push only — read+write)
-        if: github.event_name == 'push'
-        uses: julia-actions/cache@v3
-        continue-on-error: true
-        with:
-          cache-compiled: 'false'
-      - name: Cache Julia depot (PR — restore only)
-        if: github.event_name != 'push'
-        uses: actions/cache/restore@v5
-        continue-on-error: true
-        with:
-          path: |
-            ~/.julia/artifacts
-            ~/.julia/packages
-            ~/.julia/registries
-            ~/.julia/scratchspaces
-            ~/.julia/logs
-          # Primary key intentionally won't match (run_id is unique); the
-          # restore-keys prefix matches julia-actions/cache's key scheme
-          # `${cache-name};os=${runner.os};${matrix...}` so we pull the most
-          # recent cache from a main push for this same matrix cell.
-          key: julia-cache;workflow=${{ github.workflow }};job=${{ github.job }};os=${{ runner.os }};group=${{ matrix.group }};version=${{ matrix.version }};run_id=${{ github.run_id }};run_attempt=${{ github.run_attempt }}
-          restore-keys: |
-            julia-cache;workflow=${{ github.workflow }};job=${{ github.job }};os=${{ runner.os }};group=${{ matrix.group }};version=${{ matrix.version }};
-      - name: Develop local path deps (Julia < 1.11)
-        shell: julia --color=yes --project=. {0}
-        run: |
-          using Pkg
-          if VERSION < v"1.11.0-DEV.0"
-            toml = Pkg.TOML.parsefile("Project.toml")
-            if haskey(toml, "sources")
-              specs = Pkg.PackageSpec[]
-              for (dep, spec) in toml["sources"]
-                if spec isa Dict && haskey(spec, "path") && isdir(spec["path"])
-                  @info "Developing" dep spec["path"]
-                  push!(specs, Pkg.PackageSpec(path=spec["path"]))
-                end
-              end
-              isempty(specs) || Pkg.develop(specs)
-            end
-          end
-      - uses: julia-actions/julia-buildpkg@v1
-      - uses: julia-actions/julia-runtest@v1
-        with:
-          coverage: false
-          check_bounds: auto
-        env:
-          GROUP: ${{ matrix.group }}
-      - uses: julia-actions/julia-processcoverage@v1
-      - uses: codecov/codecov-action@v6
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          files: lcov.info
-          fail_ci_if_error: false
-          disable_safe_directory: true
+  tests:
+    uses: "SciML/.github/.github/workflows/grouped-tests.yml@v1"
+    with:
+      check-bounds: auto
+      coverage: false
+    secrets: "inherit"

--- a/test/test_groups.toml
+++ b/test/test_groups.toml
@@ -1,0 +1,2 @@
+[Core]
+versions = ["lts", "1", "pre"]


### PR DESCRIPTION
## Summary

Converts the root `CI.yml` test workflow from a hand-maintained `strategy.matrix` into the thin `SciML/.github/.github/workflows/grouped-tests.yml@v1` caller, with the matrix declared once in a new root `test/test_groups.toml`. The `Sublibrary CI` workflow (which calls `sublibrary-project-tests.yml@v1`) is untouched.

The workflow filename and `name: CI` are preserved, so the branch-protection status-check name is unchanged. The existing `on:` triggers and `concurrency:` block are kept verbatim.

## Matrix

The old `test` job ran a `group: [Core]` × `version: [lts, 1, pre]` matrix (no excludes/includes) — 3 cells. `test/test_groups.toml`:

```toml
[Core]
versions = ["lts", "1", "pre"]
```

## Per-group / per-job specials carried over

- Root `test/runtests.jl` dispatches on `GROUP` (the default), so **no `group-env-name` override** is needed.
- Old job used `check_bounds: auto` → `with: check-bounds: auto`.
- Old job set `coverage: false` → `with: coverage: false`.
- Single OS (ubuntu-latest), default runner, `timeout-minutes: 120` (the workflow default), `num_threads = 1`, no `continue-on-error` — all defaults, nothing else to set.

## Verified matrix match

Ran `scripts/compute_affected_sublibraries.jl <repo> --root-matrix` from `SciML/.github@v1` against this branch. It emits exactly:

```
Core × lts, Core × 1, Core × pre
```

**3/3 exact match** with the old embedded matrix. TOML and YAML both parse cleanly. The package test suite was not run locally (CI validates).

Ignore until reviewed by @ChrisRackauckas.