### PR TITLE
Add QA (Aqua/JET) groups to sublibraries (SciML/.github#77)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -19,8 +19,10 @@ julia = "1.10"
 CanonicalMoments = "0.1"
 DiscreteMeasures = "0.1"
 OUQBase = "0.1"
+Pkg = "1.10"
 Reexport = "1.2.2"
 SafeTestsets = "0.1"
+Test = "1.10"
 SciMLTesting = "1"
 
 [extras]

--- a/lib/CanonicalMoments/Project.toml
+++ b/lib/CanonicalMoments/Project.toml
@@ -31,6 +31,7 @@ ForwardDiff = "0.10, 1"
 InteractiveUtils = "1.10"
 IntervalArithmetic = "0.18 - 0.20, =0.20.9"
 LinearAlgebra = "1.10"
+Pkg = "1.10"
 PolynomialRoots = "1.0"
 Polynomials = "4"
 Random = "1.10"
@@ -49,6 +50,7 @@ DiscreteMeasures = { path = "../DiscreteMeasures" }
 [extras]
 InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
 IntervalArithmetic = "d1acc4aa-44c8-5952-acd4-ba5d80a2a253"
+Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 PolynomialRoots = "3a141323-8675-5d76-9d11-e1df1406c778"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
@@ -57,4 +59,4 @@ StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["InteractiveUtils", "IntervalArithmetic", "PolynomialRoots", "Random", "SafeTestsets", "SpecialFunctions", "StaticArrays", "Test"]
+test = ["InteractiveUtils", "IntervalArithmetic", "Pkg", "PolynomialRoots", "Random", "SafeTestsets", "SpecialFunctions", "StaticArrays", "Test"]

--- a/lib/CanonicalMoments/test/qa/Project.toml
+++ b/lib/CanonicalMoments/test/qa/Project.toml
@@ -1,0 +1,18 @@
+[deps]
+Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
+CanonicalMoments = "58d2c334-1a3c-4862-bb37-9012b9e58a38"
+DiscreteMeasures = "7766d772-2108-41ee-a4bd-11c51440a39b"
+JET = "c3a54625-cd67-489e-a8e7-0a5a0ff4e31b"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[sources]
+CanonicalMoments = {path = "../.."}
+DiscreteMeasures = {path = "../../../DiscreteMeasures"}
+
+[compat]
+Aqua = "0.8"
+CanonicalMoments = "0.1"
+DiscreteMeasures = "0.1"
+JET = "0.9, 0.10, 0.11"
+Test = "1"
+julia = "1.10"

--- a/lib/CanonicalMoments/test/qa/qa.jl
+++ b/lib/CanonicalMoments/test/qa/qa.jl
@@ -1,0 +1,12 @@
+using CanonicalMoments
+using Aqua
+using JET
+using Test
+
+@testset "Aqua" begin
+    Aqua.test_all(CanonicalMoments)
+end
+
+@testset "JET" begin
+    JET.test_package(CanonicalMoments; target_defined_modules = true)
+end

--- a/lib/CanonicalMoments/test/runtests.jl
+++ b/lib/CanonicalMoments/test/runtests.jl
@@ -1,11 +1,32 @@
+using Pkg
 using SafeTestsets
 using Test
 
 const TEST_GROUP = get(ENV, "OPTIMALUNCERTAINTYQUANTIFICATION_TEST_GROUP", "All")
 
+function activate_qa_env()
+    Pkg.activate(joinpath(@__DIR__, "qa"))
+    # On Julia < 1.11, the [sources] section in Project.toml is not honored.
+    # Manually Pkg.develop the local path dependencies so QA tests the PR branch code.
+    if VERSION < v"1.11.0-DEV.0"
+        Pkg.develop(
+            [
+                Pkg.PackageSpec(path = joinpath(@__DIR__, "..")),
+                Pkg.PackageSpec(path = joinpath(@__DIR__, "..", "..", "DiscreteMeasures"))
+            ]
+        )
+    end
+    return Pkg.instantiate()
+end
+
 if TEST_GROUP == "Core" || TEST_GROUP == "All"
     @safetestset "Orthogonal Polynomial Roots" include("Core/orthopoly_roots.jl")
     @safetestset "Moment Sequence" include("Core/moment_sequence.jl")
+end
+
+if (TEST_GROUP == "QA" || TEST_GROUP == "All") && isempty(VERSION.prerelease)
+    activate_qa_env()
+    @safetestset "Quality Assurance" include("qa/qa.jl")
 end
 
 # @safetestset "Root Domain Restriction" begin

--- a/lib/CanonicalMoments/test/test_groups.toml
+++ b/lib/CanonicalMoments/test/test_groups.toml
@@ -1,2 +1,5 @@
 [Core]
 versions = ["lts", "1", "pre"]
+
+[QA]
+versions = ["lts", "1"]

--- a/lib/DiscreteMeasures/Project.toml
+++ b/lib/DiscreteMeasures/Project.toml
@@ -12,13 +12,15 @@ IntervalArithmeticExt = "IntervalArithmetic"
 [compat]
 julia = "1.10"
 IntervalArithmetic = "0.16 - 0.20, =0.20.9"
+Pkg = "1.10"
 SafeTestsets = "0.1"
 Test = "1.10"
 
 [extras]
 IntervalArithmetic = "d1acc4aa-44c8-5952-acd4-ba5d80a2a253"
+Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["IntervalArithmetic", "SafeTestsets", "Test"]
+test = ["IntervalArithmetic", "Pkg", "SafeTestsets", "Test"]

--- a/lib/DiscreteMeasures/test/qa/Project.toml
+++ b/lib/DiscreteMeasures/test/qa/Project.toml
@@ -1,0 +1,15 @@
+[deps]
+Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
+DiscreteMeasures = "7766d772-2108-41ee-a4bd-11c51440a39b"
+JET = "c3a54625-cd67-489e-a8e7-0a5a0ff4e31b"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[sources]
+DiscreteMeasures = {path = "../.."}
+
+[compat]
+Aqua = "0.8"
+DiscreteMeasures = "0.1"
+JET = "0.9, 0.10, 0.11"
+Test = "1"
+julia = "1.10"

--- a/lib/DiscreteMeasures/test/qa/qa.jl
+++ b/lib/DiscreteMeasures/test/qa/qa.jl
@@ -1,0 +1,12 @@
+using DiscreteMeasures
+using Aqua
+using JET
+using Test
+
+@testset "Aqua" begin
+    Aqua.test_all(DiscreteMeasures)
+end
+
+@testset "JET" begin
+    JET.test_package(DiscreteMeasures; target_defined_modules = true)
+end

--- a/lib/DiscreteMeasures/test/runtests.jl
+++ b/lib/DiscreteMeasures/test/runtests.jl
@@ -1,8 +1,24 @@
+using Pkg
 using SafeTestsets
 using Test
 
 const TEST_GROUP = get(ENV, "OPTIMALUNCERTAINTYQUANTIFICATION_TEST_GROUP", "All")
 
+function activate_qa_env()
+    Pkg.activate(joinpath(@__DIR__, "qa"))
+    # On Julia < 1.11, the [sources] section in Project.toml is not honored.
+    # Manually Pkg.develop the local path dependency so QA tests the PR branch code.
+    if VERSION < v"1.11.0-DEV.0"
+        Pkg.develop(Pkg.PackageSpec(path = joinpath(@__DIR__, "..")))
+    end
+    return Pkg.instantiate()
+end
+
 if TEST_GROUP == "Core" || TEST_GROUP == "All"
     @safetestset "Discrete Measures" include("Core/discrete_measures_tests.jl")
+end
+
+if (TEST_GROUP == "QA" || TEST_GROUP == "All") && isempty(VERSION.prerelease)
+    activate_qa_env()
+    @safetestset "Quality Assurance" include("qa/qa.jl")
 end

--- a/lib/DiscreteMeasures/test/test_groups.toml
+++ b/lib/DiscreteMeasures/test/test_groups.toml
@@ -1,2 +1,5 @@
 [Core]
 versions = ["lts", "1", "pre"]
+
+[QA]
+versions = ["lts", "1"]

--- a/lib/OUQBase/Project.toml
+++ b/lib/OUQBase/Project.toml
@@ -30,6 +30,7 @@ NaNMath = "1.1.3"
 Optimization = "5"
 OptimizationBBO = "0.4"
 OrderedCollections = "1.7.0"
+Pkg = "1.10"
 PolynomialRoots = "1"
 Polynomials = "4.0.13"
 Reexport = "1.2.2"
@@ -45,8 +46,9 @@ DiscreteMeasures = { path = "../DiscreteMeasures" }
 
 [extras]
 OptimizationBBO = "3e6eede4-6085-4f62-9a71-46d9bc1eb92b"
+Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["OptimizationBBO", "SafeTestsets", "Test"]
+test = ["OptimizationBBO", "Pkg", "SafeTestsets", "Test"]

--- a/lib/OUQBase/test/qa/Project.toml
+++ b/lib/OUQBase/test/qa/Project.toml
@@ -1,0 +1,21 @@
+[deps]
+Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
+CanonicalMoments = "58d2c334-1a3c-4862-bb37-9012b9e58a38"
+DiscreteMeasures = "7766d772-2108-41ee-a4bd-11c51440a39b"
+JET = "c3a54625-cd67-489e-a8e7-0a5a0ff4e31b"
+OUQBase = "01930cae-99d2-7439-8f4f-ace2ece9f1b9"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[sources]
+CanonicalMoments = {path = "../../../CanonicalMoments"}
+DiscreteMeasures = {path = "../../../DiscreteMeasures"}
+OUQBase = {path = "../.."}
+
+[compat]
+Aqua = "0.8"
+CanonicalMoments = "0.1"
+DiscreteMeasures = "0.1"
+JET = "0.9, 0.10, 0.11"
+OUQBase = "0.1"
+Test = "1"
+julia = "1.10"

--- a/lib/OUQBase/test/qa/qa.jl
+++ b/lib/OUQBase/test/qa/qa.jl
@@ -1,0 +1,12 @@
+using OUQBase
+using Aqua
+using JET
+using Test
+
+@testset "Aqua" begin
+    Aqua.test_all(OUQBase)
+end
+
+@testset "JET" begin
+    JET.test_package(OUQBase; target_defined_modules = true)
+end

--- a/lib/OUQBase/test/runtests.jl
+++ b/lib/OUQBase/test/runtests.jl
@@ -1,7 +1,24 @@
+using Pkg
 using SafeTestsets
 using Test
 
 const TEST_GROUP = get(ENV, "OPTIMALUNCERTAINTYQUANTIFICATION_TEST_GROUP", "All")
+
+function activate_qa_env()
+    Pkg.activate(joinpath(@__DIR__, "qa"))
+    # On Julia < 1.11, the [sources] section in Project.toml is not honored.
+    # Manually Pkg.develop the local path dependencies so QA tests the PR branch code.
+    if VERSION < v"1.11.0-DEV.0"
+        Pkg.develop(
+            [
+                Pkg.PackageSpec(path = joinpath(@__DIR__, "..")),
+                Pkg.PackageSpec(path = joinpath(@__DIR__, "..", "..", "CanonicalMoments")),
+                Pkg.PackageSpec(path = joinpath(@__DIR__, "..", "..", "DiscreteMeasures"))
+            ]
+        )
+    end
+    return Pkg.instantiate()
+end
 
 if TEST_GROUP == "Core" || TEST_GROUP == "All"
     @safetestset "Flood Problem (Q only)" include("Core/FloodProblem/Q_only.jl")
@@ -13,4 +30,9 @@ if TEST_GROUP == "Core" || TEST_GROUP == "All"
     @testset "Flood Problem (canonical moments objective)" begin
         include("Core/FloodProblem/test_canonical_moments.jl")
     end
+end
+
+if (TEST_GROUP == "QA" || TEST_GROUP == "All") && isempty(VERSION.prerelease)
+    activate_qa_env()
+    @safetestset "Quality Assurance" include("qa/qa.jl")
 end

--- a/lib/OUQBase/test/test_groups.toml
+++ b/lib/OUQBase/test/test_groups.toml
@@ -1,2 +1,5 @@
 [Core]
 versions = ["lts", "1", "pre"]
+
+[QA]
+versions = ["lts", "1"]

--- a/test/qa/Project.toml
+++ b/test/qa/Project.toml
@@ -1,0 +1,24 @@
+[deps]
+Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
+CanonicalMoments = "58d2c334-1a3c-4862-bb37-9012b9e58a38"
+DiscreteMeasures = "7766d772-2108-41ee-a4bd-11c51440a39b"
+JET = "c3a54625-cd67-489e-a8e7-0a5a0ff4e31b"
+OUQBase = "01930cae-99d2-7439-8f4f-ace2ece9f1b9"
+OptimalUncertaintyQuantification = "91ab1271-1799-4997-981e-07ad84422b0d"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[sources]
+CanonicalMoments = {path = "../../lib/CanonicalMoments"}
+DiscreteMeasures = {path = "../../lib/DiscreteMeasures"}
+OUQBase = {path = "../../lib/OUQBase"}
+OptimalUncertaintyQuantification = {path = "../.."}
+
+[compat]
+Aqua = "0.8"
+CanonicalMoments = "0.1"
+DiscreteMeasures = "0.1"
+JET = "0.9, 0.10, 0.11"
+OUQBase = "0.1"
+OptimalUncertaintyQuantification = "0.1"
+Test = "1"
+julia = "1.10"

--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -1,0 +1,12 @@
+using OptimalUncertaintyQuantification
+using Aqua
+using JET
+using Test
+
+@testset "Aqua" begin
+    Aqua.test_all(OptimalUncertaintyQuantification)
+end
+
+@testset "JET" begin
+    JET.test_package(OptimalUncertaintyQuantification; target_defined_modules = true)
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -53,7 +53,13 @@ const GROUP = get(ENV, "GROUP", "All")
         withenv("OPTIMALUNCERTAINTYQUANTIFICATION_TEST_GROUP" => test_group) do
             Pkg.test(base_group, julia_args = ["--check-bounds=auto", "--compiled-modules=yes", "--depwarn=yes"], force_latest_compatible_version = false, allow_reresolve = true)
         end
-    elseif GROUP == "All" || GROUP == "Core"
-        run_tests(; core = () -> @safetestset("Umbrella Load", include("umbrella_load.jl")))
+    elseif GROUP == "All" || GROUP == "Core" || GROUP == "QA"
+        run_tests(;
+            core = () -> @safetestset("Umbrella Load", include("umbrella_load.jl")),
+            # QA (Aqua/JET): dep-adding group in its own sub-env (test/qa), excluded from "All".
+            groups = Dict(
+                "QA" => (; env = joinpath(@__DIR__, "qa"), body = joinpath(@__DIR__, "qa", "qa.jl")),
+            ),
+        )
     end
 end # @time

--- a/test/test_groups.toml
+++ b/test/test_groups.toml
@@ -1,2 +1,5 @@
 [Core]
 versions = ["lts", "1", "pre"]
+
+[QA]
+versions = ["lts", "1"]


### PR DESCRIPTION
Part of SciML/.github#77 (canonical QA groups across monorepo sublibraries).

Adds a canonical QA test group (Aqua + JET, standard only) to every unit of this repo:

- **ROOT** (`OptimalUncertaintyQuantification`): `test/qa/{Project.toml,qa.jl}`, QA dispatch in `test/runtests.jl` gated on `GROUP`, `[QA]` cell in `test/test_groups.toml`
- **lib/CanonicalMoments**: `test/qa` env, QA dispatch gated on `OPTIMALUNCERTAINTYQUANTIFICATION_TEST_GROUP`, `[QA]` cell
- **lib/DiscreteMeasures**: same
- **lib/OUQBase**: same

Details:
- Each `test/qa/Project.toml` carries Aqua + JET + Test plus the package (and its local-path deps) via `[sources]`, with full `[compat]` (`Aqua = "0.8"`, `JET = "0.9, 0.10, 0.11"`, `julia = "1.10"`).
- `qa.jl` runs `Aqua.test_all(<Pkg>)` and `JET.test_package(<Pkg>; target_defined_modules = true)`.
- On Julia < 1.11 the QA env `Pkg.develop`s the local path dependencies (mirroring the existing root runtests pattern), since `[sources]` is not honored there.
- `[QA]` groups declare `versions = ["lts", "1"]` (no `pre`), ubuntu-only.
- `Pkg` added to each unit's test extras/targets with a `[compat]` entry so Aqua `deps_compat` stays green.

Verification: static only (TOML parse, `Meta.parseall` of all touched `.jl` files, `[sources]` path resolution, Runic clean). QA findings, if any, will be triaged from CI per the established mark-broken+issue policy.

Further batches may be pushed to this branch. Ignore until reviewed by @ChrisRackauckas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)