### PR TITLE
Fix downgrade CI config (julia_floor)

### DIFF
--- a/.github/workflows/DowngradeSublibraries.yml
+++ b/.github/workflows/DowngradeSublibraries.yml
@@ -22,6 +22,10 @@ jobs:
     uses: "SciML/.github/.github/workflows/sublibrary-downgrade.yml@v1"
     secrets: "inherit"
     with:
+      # The sublibrary downgrade resolver passes julia-version straight to
+      # `resolve.jl --julia=`, which requires a numeric registry-compat spec and
+      # rejects the "lts" channel alias. Pin to the numeric sublibrary floor.
+      julia-version: "1.10"
       group-env-name: "OPTIMALUNCERTAINTYQUANTIFICATION_TEST_GROUP"
       group-env-value: "Core"
       # Every lib/* sublibrary is downgrade-tested (projects auto-discovered, no exclusions).


### PR DESCRIPTION
## Problem

The `Downgrade Sublibraries` workflow fails at the `julia-actions/julia-downgrade-compat@v2` step (before buildpkg/runtest) for every `lib/*` sublibrary, e.g.:

```
[ERROR] Invalid compat version spec: --julia=lts
ERROR: LoadError: failed process: Process(`... resolve.jl lib/CanonicalMoments --min=@alldeps --julia=lts`, ProcessExited(1))
```

Root cause: the caller did not set `julia-version`, so it inherited the centralized `sublibrary-downgrade.yml@v1` default of `"lts"`. That value is forwarded verbatim into `julia-downgrade-compat`'s sublibrary resolver as `resolve.jl --julia=lts`. The resolver only accepts a **numeric registry-compat** version spec (e.g. `1.10`), not the `lts` channel alias, so resolution aborts.

This is config-only. The Julia runtime is unaffected: `lts` already resolved to `1.10.11` at the setup step, and the sublibrary `[compat] julia` floor is `"1.10"`, so pinning `julia-version: "1.10"` produces the identical runtime while giving the resolver a value it accepts.

## Pre-existing vs introduced

`Downgrade Sublibraries` on `main` was **green on 2026-06-07** and **flipped to failure on 2026-06-08**, coinciding with the move to the centralized sublibrary downgrade workflow. The main (non-sublibrary) `Downgrade` workflow is unaffected (it routes `lts` through `downgrade.yml@v1`, which converts it to a numeric spec) and stays green.

## Change

Set `julia-version: "1.10"` (the numeric sublibrary floor) in `.github/workflows/DowngradeSublibraries.yml`. No `Project.toml`, source, or test changes. `actionlint` passes.

Ignore until reviewed by @ChrisRackauckas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)