### PR TITLE
Route umbrella QA group through the `qa` keyword (fixes GROUP=QA dispatch)

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -56,10 +56,10 @@ const GROUP = get(ENV, "GROUP", "All")
     elseif GROUP == "All" || GROUP == "Core" || GROUP == "QA"
         run_tests(;
             core = () -> @safetestset("Umbrella Load", include("umbrella_load.jl")),
-            # QA (Aqua/JET): dep-adding group in its own sub-env (test/qa), excluded from "All".
-            groups = Dict(
-                "QA" => (; env = joinpath(@__DIR__, "qa"), body = joinpath(@__DIR__, "qa", "qa.jl")),
-            ),
+            # QA (Aqua/JET): dep-adding group in its own sub-env (test/qa). It is the
+            # reserved "QA" group, so it must be passed via the `qa` keyword (the
+            # reserved name is not routed through `groups`).
+            qa = (; env = joinpath(@__DIR__, "qa"), body = joinpath(@__DIR__, "qa", "qa.jl")),
         )
     end
 end # @time


### PR DESCRIPTION
## Problem

The `tests / QA` checks on `main` fail with:

```
ERROR: LoadError: ArgumentError: run_tests: GROUP="QA" was requested but no `qa` body was provided
```

The root `test/runtests.jl` registered the QA (Aqua/JET) group via
`groups = Dict("QA" => (; env, body))`. But `"QA"` is a *reserved* group
name in SciMLTesting's `run_tests`: when `GROUP="QA"`, the dispatcher
routes to the `qa` keyword body, **not** through the `groups` table. With
`qa` left unset, the reserved-name branch throws the `ArgumentError`
above.

## Fix

Pass the QA group via the `qa = (; env, body)` keyword instead of `groups`.
No other behavior changes; the QA env/body are unchanged
(`test/qa/Project.toml` + `test/qa/qa.jl`).

## Local verification

On Julia 1.12 (the `julia 1` matrix entry), `GROUP=QA Pkg.test()` now runs
the umbrella Aqua+JET suite cleanly:

```
Test Summary: | Pass  Total     Time
QA            |   12     12  1m58.8s
     Testing OptimalUncertaintyQuantification tests passed
```

Runic check (`runic --check`) passes on the edited file.

## Scope / remaining reds (not addressed here)

This PR fixes the `julia 1` QA check. Other `main` reds have **different**
root causes and are out of scope for this focused PR:

- `tests / Core (julia lts)` and `tests / QA (julia lts)` fail *earlier*, at
  `julia-buildpkg`, with `expected package CanonicalMoments ... to be
  registered`. On Julia 1.10 the `[sources]` table is not auto-resolved, and
  the centralized `SciML/.github` `tests.yml` skips its "Develop in-repo
  `[sources]` path deps" step when `project == '.'` — so a monorepo *root*
  project with in-repo `[sources]` never gets its path deps developed on
  1.10. That is a `SciML/.github` workflow bug, tracked separately.
- `sublibraries / lib/OUQBase [QA]` / `lib/CanonicalMoments [QA]` report real
  Aqua/JET findings (stale dep `PolynomialRoots`, a type-piracy on
  `CanonicalMoments.RawMomentSequence`, several JET errors). These are genuine
  code findings, not harness bugs.
- `Downgrade` / `Downgrade Sublibraries` fail because the downgrade resolver
  cannot handle the unregistered in-repo `[sources]` UUIDs.

Please ignore until reviewed by @ChrisRackauckas.
