### PR TITLE
Fix sublibrary QA (Aqua/JET) findings in OUQBase and CanonicalMoments

### DIFF
--- a/lib/CanonicalMoments/src/CanonicalMoments.jl
+++ b/lib/CanonicalMoments/src/CanonicalMoments.jl
@@ -14,12 +14,14 @@ import LinearAlgebra: issymmetric
 import DiscreteMeasures: support, weights
 
 function DEFAULT_ROOT_SOLVER(C, args...; kwargs...)
+    # The closed-form solvers take only the coefficient vector; any extra
+    # args/kwargs are solver options that only the generic fallback consumes.
     return if length(C) == 3      # 2nd order
-        quadratic_eq_sridhare(C, args...; kwargs...)
+        quadratic_eq_sridhare(C)
     elseif length(C) == 4  # 3rd order
-        simple_real_cubic_eq(C, args...; kwargs...)
+        simple_real_cubic_eq(C)
     elseif length(C) == 5  # 4th order
-        simple_real_quartic_eq(C, args...; kwargs...)
+        simple_real_quartic_eq(C)
     else
         Polynomials.roots(Polynomial(C), args...; kwargs...)
     end

--- a/lib/OUQBase/src/interface.jl
+++ b/lib/OUQBase/src/interface.jl
@@ -147,32 +147,48 @@ struct OUQSystem{A <: ObjectiveType, B <: AbstractReductionAlgorithm, P} <: Abst
     admissible_set::AdmissibleSet
     reduction_data::B
     parameters::P
-    function OUQSystem(;
-            objective,
-            admissible_set,
-            reduction_alg::B,
-            parameters = SciMLBase.NullParameters(),
-        ) where {B}
-        reduction_data = ReductionData(admissible_set, reduction_alg) # Note: reduction_data is the populated reduction_alg.
-        objective = process_objective(objective)
-        return new{typeof(objective), B, typeof(parameters)}(
-            objective,
-            admissible_set,
-            reduction_data,
-            parameters,
-        )
+    function OUQSystem{A, B, P}(
+            objective::A,
+            admissible_set::AdmissibleSet,
+            reduction_data::B,
+            parameters::P,
+        ) where {A <: ObjectiveType, B <: AbstractReductionAlgorithm, P}
+        return new{A, B, P}(objective, admissible_set, reduction_data, parameters)
     end
+end
+
+function OUQSystem(;
+        objective,
+        admissible_set,
+        reduction_alg::AbstractReductionAlgorithm,
+        parameters = SciMLBase.NullParameters(),
+    )
+    reduction_data = ReductionData(admissible_set, reduction_alg) # Note: reduction_data is the populated reduction_alg.
+    # Function barrier: process_objective returns a Union, so build the concretely
+    # parameterized OUQSystem behind a dispatch on the realized objective type.
+    return _OUQSystem(process_objective(objective), admissible_set, reduction_data, parameters)
+end
+
+function _OUQSystem(
+        objective::A,
+        admissible_set::AdmissibleSet,
+        reduction_data::B,
+        parameters::P,
+    ) where {A <: ObjectiveType, B <: AbstractReductionAlgorithm, P}
+    return OUQSystem{A, B, P}(objective, admissible_set, reduction_data, parameters)
 end
 
 objective(ouq_sys::OUQSystem) = ouq_sys.objective
 random_variable_map(ouq_sys::OUQSystem) = ouq_sys.admissible_set.random_variable_map
 constraints_map(ouq_sys::OUQSystem) = ouq_sys.reduction_data.constraints_map
-raw_moments_map(ouq_sys::OUQSystem) =
-    ouq_sys.reduction_data isa StengerCanonicalMoments ?
-    ouq_sys.reduction_data.raw_moments_map : nothing
-p_free_map(ouq_sys::OUQSystem) =
-    ouq_sys.reduction_data isa StengerCanonicalMoments ? ouq_sys.reduction_data.p_free_map :
-    nothing
+# Dispatch on the (concretely typed) reduction_data so the accessors stay type
+# stable: a StengerCanonicalMoments system returns its dict, anything else nothing.
+raw_moments_map(ouq_sys::OUQSystem) = raw_moments_map(ouq_sys.reduction_data)
+raw_moments_map(reduction_data::StengerCanonicalMoments) = reduction_data.raw_moments_map
+raw_moments_map(::AbstractReductionAlgorithm) = nothing
+p_free_map(ouq_sys::OUQSystem) = p_free_map(ouq_sys.reduction_data)
+p_free_map(reduction_data::StengerCanonicalMoments) = reduction_data.p_free_map
+p_free_map(::AbstractReductionAlgorithm) = nothing
 
 
 function get_group_name(var, admissible_set::AdmissibleSet)

--- a/lib/OUQBase/src/reduction_transformations/canonical_moments.jl
+++ b/lib/OUQBase/src/reduction_transformations/canonical_moments.jl
@@ -15,7 +15,7 @@ function get_raw_moment_order(equation::Union{Equation, Inequality}, random_var:
     return order
 end
 
-function CanonicalMoments.RawMomentSequence(
+function build_raw_moment_sequence(
         random_var::Num,
         constraints::Vector{Union{Equation, Inequality}},
     )
@@ -36,7 +36,7 @@ function create_raw_moments_map(admissible_set::AbstractAdmissibleSet)
         length(admissible_set.random_variable_map[k]) == 1 ||
             error("Group is not independent, cannot use canonical moments")
         random_var = only(admissible_set.random_variable_map[k])
-        raw_moments_map[k] = RawMomentSequence(random_var, v)
+        raw_moments_map[k] = build_raw_moment_sequence(random_var, v)
     end
     return raw_moments_map
 end
@@ -82,8 +82,8 @@ function discrete_measure_map(
         ::Symbolic,
     )
     transformed_discrete_measure_map = OrderedDict{Symbol, DiscreteMeasure}()
-    _raw_moments_map = raw_moments_map(ouq_sys)
-    _p_free_map = p_free_map(ouq_sys)
+    _raw_moments_map = reduction_alg.raw_moments_map
+    _p_free_map = reduction_alg.p_free_map
     for (k, v) in constraints_map(ouq_sys)
         transform_functor = DiscreteMeasureTransform1(_raw_moments_map[k])
         transformed_discrete_measure_map[k] = transform_functor(

--- a/lib/OUQBase/test/qa/qa.jl
+++ b/lib/OUQBase/test/qa/qa.jl
@@ -3,9 +3,6 @@ using SciMLTesting, OUQBase, JET, Test
 run_qa(
     OUQBase;
     explicit_imports = true,
-    # piracies: OUQBase defines `CanonicalMoments.RawMomentSequence(::Symbolics.Num, ...)`,
-    # owning neither the type nor the arg types; resolving it is a design change.
-    aqua_broken = (:piracies,),  # SciML/OptimalUncertaintyQuantification.jl#33
     ei_kwargs = (;
         # Explicit imports of names that are non-public in the upstream majors OUQBase
         # actually resolves. OUQBase's [compat] caps SciMLBase 2.x / Symbolics 6.x /


### PR DESCRIPTION
## Problem

The `sublibraries / lib/OUQBase [QA]` and `sublibraries / lib/CanonicalMoments [QA]` checks (added in #17) fail on `main` with **real** Aqua/JET findings — they are not harness bugs. This PR fixes them at the source.

### OUQBase QA findings (Aqua 9 pass / 3 fail + 7 JET errors)

- **Aqua stale dep**: `PolynomialRoots` is declared in `[deps]` but never used anywhere in `src` or `test`. Removed it (and its compat).
- **Aqua piracy**: `CanonicalMoments.RawMomentSequence(::Num, ::Vector{Union{Equation,Inequality}})` defined a constructor on a *foreign* type with *foreign* argument types. Renamed to an internal `build_raw_moment_sequence`; it was only ever called inside OUQBase, so behavior is unchanged.
- **JET `OUQBase.simplify is not defined`**: the bare `simplify` binding is ambiguous between the `using ModelingToolkit` and `using Symbolics` imports. Qualified it as `Symbolics.simplify` (matching every other `simplify` call in the file).
- **JET `local variable objective is not defined`**: a `@debug` interpolated `objective` one line *before* `objective = ouq_sys.objective`. Reordered.
- **JET `getindex(::Nothing, ::Any)`**: `raw_moments_map`/`p_free_map` returned `Union{Nothing, OrderedDict}` via a runtime `isa` ternary. Made them dispatch on the concretely typed `reduction_data`, and read the maps off the concrete `StengerCanonicalMoments` argument inside `discrete_measure_map`, so they stay type stable.
- **JET `convert(...)` union split** in the `OUQSystem` constructor: `process_objective` returns a `Union`, so routed it through a `_OUQSystem` function barrier to build the struct with a concrete objective type parameter.

### CanonicalMoments QA finding (3 JET errors)

- **JET `no matching method found kwcall(...)`**: `DEFAULT_ROOT_SOLVER` forwarded `args...; kwargs...` to the closed-form solvers (`quadratic_eq_sridhare`, `simple_real_cubic_eq`, `simple_real_quartic_eq`), which accept only the coefficient vector. Only the generic `Polynomials.roots` fallback consumes those options, so they are now passed only there.

## Local verification

- **OUQBase QA, Julia 1.12**: Aqua **11/11**, JET **1/1** (was 9/3 + 7 JET errors).
- **CanonicalMoments JET, Julia 1.10 (lts)**: **1/1** (was 3 errors).
- **CanonicalMoments** analytic root-solver branches (quadratic/cubic/quartic + generic fallback) still return correct roots (`orthopoly_roots.jl` Core tests pass 11/11).
- **OUQBase Core** `Pkg.test()` on Julia 1.12 passes, including the canonical-moments objective test that exercises the refactored accessor / constructor path.

## Scope / remaining `main` reds (NOT addressed here)

These have different root causes and need cross-repo coordination, so they are out of scope for this focused PR:

- `tests / Core (julia lts)` and `tests / QA (julia lts)` fail at `julia-buildpkg` with `expected package CanonicalMoments ... to be registered`. The centralized `SciML/.github` `tests.yml` skips developing in-repo `[sources]` path deps when `project == '.'`, and on Julia 1.10 `[sources]` is not auto-resolved — a `SciML/.github` workflow issue.
- `Downgrade` / `Downgrade Sublibraries` fail because `julia-actions/julia-downgrade-compat@v2` errors with `unknown package UUID` on the unregistered in-repo `[sources]` package — an upstream action limitation.
- `tests / QA (julia 1)` GROUP=QA dispatch is fixed by the separate #22.

Please ignore until reviewed by @ChrisRackauckas.