### PR TITLE
Drop older SciML major versions from compat

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -23,7 +23,7 @@ Pkg = "1.10"
 Reexport = "1.2.2"
 SafeTestsets = "0.1"
 Test = "1.10"
-SciMLTesting = "1"
+SciMLTesting = "2"
 
 [extras]
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"


### PR DESCRIPTION
**Please ignore this PR until it has been reviewed by @ChrisRackauckas.**

## What changed

Pure `[compat]` edits that **drop older major versions of SciML packages**. For each SciML dependency, only the current major remains (existing lower bound on that major is kept). No code, tests, or package version were changed.

- `Project.toml` [extras] `SciMLTesting`: `1` → `2` (drop 1; current SciML major is 2)

## Why

Supporting multiple SciML majors keeps untested resolver windows. The current major is the one in the General registry; older majors are dropped even when that current major is recent.

## Verification

Current majors come from JuliaRegistries/General `Versions.toml`. Not verified here: the full test suite, QA, or a live `julia-downgrade-compat` run.
