### PR TITLE
Fix Documentation build: CanonicalMoments SymbolicsExt precompile failure on Symbolics 7

### DIFF
--- a/lib/CanonicalMoments/ext/SymbolicsExt.jl
+++ b/lib/CanonicalMoments/ext/SymbolicsExt.jl
@@ -1,8 +1,6 @@
 module SymbolicsExt
 using Symbolics
-import Symbolics: unwrap, wrap, array_term
 using CanonicalMoments
-using LinearAlgebra
 
 @register_array_symbolic (alg::CanonicalMoments.EigvalSupportAlg)(M::AbstractMatrix{<:Real}) begin
     size = (size(M)[1],)
@@ -14,26 +12,24 @@ end
     eltype = eltype(M)
 end
 
+# `AbstractVecOrMat` is a `Union` alias, which `@register_array_symbolic` cannot
+# introspect; `AbstractArray` covers both the vector and matrix cases.
 @register_array_symbolic (alg::CanonicalMoments.EigvecWeightAlg)(
     M::AbstractMatrix{<:Real},
-    λ::AbstractVecOrMat{<:Real},
+    λ::AbstractArray{<:Real},
 ) begin
     size = size(M)
     eltype = eltype(M)
 end
 
-function CanonicalMoments._companion_matrix(B::Vector{Num}, C::Vector{Num})
-    dv = -B
-    ndims = length(B)
-    ev = sqrt.(C[2:end]) # Probably use views here
-    _comp_mat_unwrapped = array_term(
-        SymTridiagonal,
-        unwrap.(dv),
-        unwrap.(ev);
-        eltype = Real,
-        size = (ndims, ndims),
-    )
-    return wrap(_comp_mat_unwrapped)
+# Registering the companion matrix constructor keeps it lazy for symbolic inputs
+# while deferring to the numeric implementation otherwise.
+@register_array_symbolic CanonicalMoments._companion_matrix(
+    B::AbstractVector{<:Real},
+    C::AbstractVector{<:Real},
+) begin
+    size = (length(B), length(B))
+    eltype = Real
 end
 
 end


### PR DESCRIPTION
## Problem

The [Documentation build](https://github.com/SciML/OptimalUncertaintyQuantification.jl/actions/runs/32519199333) fails before `makedocs` is reached, while precompiling `CanonicalMoments → SymbolicsExt`:

```
WARNING: Imported binding Symbolics.array_term was undeclared at import time during import to SymbolicsExt.
ERROR: LoadError: FieldError: type Union has no field `parameters`, available fields: `a`, `b`
  [2] (::Symbolics.var"#is_wrapped_array_eltype#wrap_func_expr##9")(T::Type)
    @ Symbolics .../src/wrapper-types.jl:220
```

That failure cascades into `Failed to precompile OUQBase`, so `docs/make.jl` dies at its first `using`.

## Root cause

#40 widened the `CanonicalMoments` compat entry to `Symbolics = "6.29.2, 7.30"`. `OUQBase` also allows `ModelingToolkit = "9.69, 11.31"`, so the docs environment now resolves Symbolics 7 (7.36.0 / MTK 11.40.0 locally). Two things in `lib/CanonicalMoments/ext/SymbolicsExt.jl` do not survive that:

1. `@register_array_symbolic` introspects every declared argument type. `AbstractVecOrMat{<:Real}` is a `UnionAll` whose body is a `Union`, and Symbolics 7's `is_wrapped_array_eltype` unwraps the `UnionAll` and then reads `.parameters`, which a `Union` does not have. Hence the `FieldError`.
2. `Symbolics.array_term` was removed in Symbolics 7 (hence the undeclared-binding warning), so the hand-rolled companion matrix term in `_companion_matrix` cannot be constructed.

## Fix

1. Declare the second argument of the `EigvecWeightAlg` registration as `AbstractArray{<:Real}`. This still covers the vector and matrix cases that `AbstractVecOrMat` was there for, but is not a `Union`, so the macro can introspect it. (Registering `AbstractVector` and `AbstractMatrix` separately is not an option: both expand to the same `(AbstractMatrix, BasicSymbolic)` method and trip "Method overwriting is not permitted during Module precompilation".)
2. Drop the manual `array_term` construction and instead register `CanonicalMoments._companion_matrix` itself with `@register_array_symbolic`. The macro builds the lazy array term for symbolic inputs and falls through to the existing numeric `SymTridiagonal(-B, sqrt.(C[2:end]))` implementation otherwise, which is what the old code emulated by hand. This works unchanged on Symbolics 6 and 7, so no compat entry has to be narrowed.

The now-unused `unwrap`/`wrap`/`array_term` imports and the `LinearAlgebra` dependency of the extension are removed along with the code that used them.

## Verification

- `docs/make.jl` runs to completion locally (Julia 1.12.4, Symbolics 7.36.0, ModelingToolkit 11.40.0, SymbolicUtils 4.45.0), with only the pre-existing `missing_docs` warnings that `warnonly` already tolerates.
- The extension precompiles and the symbolic path round-trips against the numeric implementation on both Symbolics 6.29.2 and 7.36.0:

```julia
@variables B[1:3] C[1:3]
A = CanonicalMoments._companion_matrix(collect(B), collect(C))   # Symbolics.Arr{Num, 2}
vals = EigvalSupportAlg()(A)                                     # Symbolics.Arr{Num, 1}
vecs = EigvecWeightAlg()(A, vals)                                # Symbolics.Arr{Num, 2}
f = Symbolics.build_function(vals, collect(B), collect(C); expression = Val(false))[1]
f([1.0, 2.0, 3.0], [1.0, 4.0, 9.0]) ≈
    EigvalSupportAlg()(CanonicalMoments._companion_matrix([1.0, 2.0, 3.0], [1.0, 4.0, 9.0]))  # true
```

- `Runic` reports no formatting diff for the changed file.

## Out of scope, but worth flagging

`OUQBase`'s Core tests still error on Symbolics 7, for an unrelated reason in `lib/OUQBase/src/operators.jl`:

```
MethodError: promote_symtype(::OUQBase.𝔼_, ::Type{Real}) is ambiguous.
Candidates:
  promote_symtype(::OUQBase.𝔼_, x)                              @ OUQBase src/operators.jl:11
  promote_symtype(::SymbolicUtils.Operator, ::Type{T}) where T   @ SymbolicUtils
```

SymbolicUtils 4 added the `::Type{T}` method, so `promote_symtype(::𝔼_, x)` needs to become `promote_symtype(::𝔼_, ::Type{T}) where {T}`. That code is not reached by the docs build, so I left it out of this PR to keep the change limited to the Documentation failure.

Made with [Cursor](https://cursor.com)