### PR TITLE
Fix OUQBase Symbolics 7 Core and QA failures

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -9,6 +9,7 @@ DiscreteMeasures = "7766d772-2108-41ee-a4bd-11c51440a39b"
 OUQBase = "01930cae-99d2-7439-8f4f-ace2ece9f1b9"
 PrecompileTools = "aea7be01-6a6a-4083-8856-8a6e6704d82a"
 Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
+Symbolics = "0c5d862f-8b57-4792-8d23-62f2024744c7"
 
 [sources]
 CanonicalMoments = { path = "lib/CanonicalMoments" }
@@ -24,6 +25,7 @@ Pkg = "1.10"
 PrecompileTools = "1.2"
 Reexport = "1.2.2"
 SafeTestsets = "0.1"
+Symbolics = "7.37"
 Test = "1.10"
 SciMLTesting = "2"
 

--- a/lib/DiscreteMeasures/ext/IntervalArithmeticExt.jl
+++ b/lib/DiscreteMeasures/ext/IntervalArithmeticExt.jl
@@ -2,10 +2,9 @@ module IntervalArithmeticExt
 
 using DiscreteMeasures, IntervalArithmetic
 
-println("Load Ext")
 function DiscreteMeasures.clamp_domain(x::Interval, lb, ub)
     bounds = interval(lb, ub)
-    return intersect(x, bounds)
+    return intersect_interval(x, bounds)
 end
 
 function DiscreteMeasures.clamp_weight(w::Interval{T}, maxw::T = one(T)) where {T}

--- a/lib/DiscreteMeasures/test/Core/discrete_measures_tests.jl
+++ b/lib/DiscreteMeasures/test/Core/discrete_measures_tests.jl
@@ -91,11 +91,12 @@ end
     end
 
     @testset "Interval Ext" begin
-        @test clamp_domain(interval(-2, -1), 0, 2) == emptyinterval()
-        @test clamp_domain(interval(-2, 1), 0, 2) == interval(0, 1)
-        @test clamp_domain(interval(0.1, 0.5), 0, 2) == interval(0.1, 0.5)
-        @test clamp_domain(interval(0.5, 5), 0, 2) == interval(0.5, 2)
-        @test clamp_domain(interval(3, 4), 0, 2) == emptyinterval()
+        # IntervalArithmetic 1.x: empty intervals compare false under `==` even when equal.
+        @test isequal(clamp_domain(interval(-2, -1), 0, 2), emptyinterval())
+        @test isequal(clamp_domain(interval(-2, 1), 0, 2), interval(0, 1))
+        @test isequal(clamp_domain(interval(0.1, 0.5), 0, 2), interval(0.1, 0.5))
+        @test isequal(clamp_domain(interval(0.5, 5), 0, 2), interval(0.5, 2))
+        @test isequal(clamp_domain(interval(3, 4), 0, 2), emptyinterval())
     end
 
 end

--- a/lib/DiscreteMeasures/test/Core/discrete_measures_tests.jl
+++ b/lib/DiscreteMeasures/test/Core/discrete_measures_tests.jl
@@ -92,11 +92,11 @@ end
 
     @testset "Interval Ext" begin
         # IntervalArithmetic 1.x: empty intervals compare false under `==` even when equal.
-        @test isequal(clamp_domain(interval(-2, -1), 0, 2), emptyinterval())
-        @test isequal(clamp_domain(interval(-2, 1), 0, 2), interval(0, 1))
-        @test isequal(clamp_domain(interval(0.1, 0.5), 0, 2), interval(0.1, 0.5))
-        @test isequal(clamp_domain(interval(0.5, 5), 0, 2), interval(0.5, 2))
-        @test isequal(clamp_domain(interval(3, 4), 0, 2), emptyinterval())
+        @test isequal_interval(clamp_domain(interval(-2, -1), 0, 2), emptyinterval())
+        @test isequal_interval(clamp_domain(interval(-2, 1), 0, 2), interval(0, 1))
+        @test isequal_interval(clamp_domain(interval(0.1, 0.5), 0, 2), interval(0.1, 0.5))
+        @test isequal_interval(clamp_domain(interval(0.5, 5), 0, 2), interval(0.5, 2))
+        @test isequal_interval(clamp_domain(interval(3, 4), 0, 2), emptyinterval())
     end
 
 end

--- a/lib/OUQBase/src/OUQBase.jl
+++ b/lib/OUQBase/src/OUQBase.jl
@@ -1,7 +1,7 @@
 module OUQBase
 using ModelingToolkit: ModelingToolkit, @named, OptimizationSystem, get_variables,
     getbounds, parameters, structural_simplify, unknowns
-using Symbolics: Symbolics, Equation, Inequality, Num, wrap
+using Symbolics: Symbolics, Equation, Inequality, Num, wrap, ≲, ≳
 using SymbolicUtils: SymbolicUtils, BasicSymbolic, @rule, substitute
 using SymbolicUtils.Rewriters: Chain
 using TermInterface: arguments
@@ -15,6 +15,9 @@ using JuMP: JuMP, @constraint, @objective, @variable, set_lower_bound, set_name,
     set_upper_bound
 using SciMLBase: SciMLBase, OptimizationFunction, OptimizationProblem
 using ADTypes: AbstractADType
+
+const _LEQ_RELATIONAL_OPERATOR = (0 ≲ 0).relational_op
+const _GEQ_RELATIONAL_OPERATOR = (0 ≳ 0).relational_op
 
 using CanonicalMoments: CanonicalMoments, DiscreteMeasureTransform1
 import CanonicalMoments: RawMomentSequence

--- a/lib/OUQBase/src/interface.jl
+++ b/lib/OUQBase/src/interface.jl
@@ -203,16 +203,14 @@ function get_group_name(var, ouq_sys::OUQSystem)
     return get_group_name(var, ouq_sys.admissible_set)
 end
 
-# `𝔼`/`ℙ` are modeled as `Symbolics.Operator`s (the same abstraction used for
-# e.g. `Differential`). `SymbolicUtils.default_is_atomic` therefore treats any
-# `𝔼(Q)`/`ℙ(Q)` application as an atomic leaf (correct for `D(x)`, but not for
-# us): we need to recurse through it to discover the underlying random
-# variable `Q` that it wraps.
-function _random_variable_is_atomic(ex)
-    if SymbolicUtils.iscall(ex) && SymbolicUtils.operation(ex) isa Operator
-        return false
+function _is_random_variable(ex, admissible_set::AdmissibleSet)
+    wrapped_ex = wrap(ex)
+    return any(values(admissible_set.random_variable_map)) do variables
+        if variables isa AbstractVector
+            return any(variable -> isequal(wrapped_ex, variable), variables)
+        end
+        return isequal(wrapped_ex, variables)
     end
-    return SymbolicUtils.default_is_atomic(ex)
 end
 
 function get_ordered_group_names(
@@ -221,12 +219,14 @@ function get_ordered_group_names(
         ensure_singleton = true,
         ensure_all = false,
     )
+    vars = get_variables(
+        expression;
+        is_atomic = ex -> _is_random_variable(ex, admissible_set),
+    )
     if ensure_singleton
-        vars = get_variables(expression; is_atomic = _random_variable_is_atomic)
         @assert length(vars) == 1 "Expression $expression has multiple random variables $vars. Disable `ensure_singleton` if this is intended."
         return unique([get_group_name(only(vars), admissible_set)])
     else
-        vars = get_variables(expression; is_atomic = _random_variable_is_atomic)
         @debug "Expression $expression has multiple random variables $vars"
         unordered_group_names = Set([get_group_name(var, admissible_set) for var in vars])
         if ensure_all

--- a/lib/OUQBase/src/interface.jl
+++ b/lib/OUQBase/src/interface.jl
@@ -203,6 +203,18 @@ function get_group_name(var, ouq_sys::OUQSystem)
     return get_group_name(var, ouq_sys.admissible_set)
 end
 
+# `𝔼`/`ℙ` are modeled as `Symbolics.Operator`s (the same abstraction used for
+# e.g. `Differential`). `SymbolicUtils.default_is_atomic` therefore treats any
+# `𝔼(Q)`/`ℙ(Q)` application as an atomic leaf (correct for `D(x)`, but not for
+# us): we need to recurse through it to discover the underlying random
+# variable `Q` that it wraps.
+function _random_variable_is_atomic(ex)
+    if SymbolicUtils.iscall(ex) && SymbolicUtils.operation(ex) isa Operator
+        return false
+    end
+    return SymbolicUtils.default_is_atomic(ex)
+end
+
 function get_ordered_group_names(
         expression,
         admissible_set::AdmissibleSet;
@@ -210,11 +222,11 @@ function get_ordered_group_names(
         ensure_all = false,
     )
     if ensure_singleton
-        vars = get_variables(expression)
+        vars = get_variables(expression; is_atomic = _random_variable_is_atomic)
         @assert length(vars) == 1 "Expression $expression has multiple random variables $vars. Disable `ensure_singleton` if this is intended."
         return unique([get_group_name(only(vars), admissible_set)])
     else
-        vars = get_variables(expression)
+        vars = get_variables(expression; is_atomic = _random_variable_is_atomic)
         @debug "Expression $expression has multiple random variables $vars"
         unordered_group_names = Set([get_group_name(var, admissible_set) for var in vars])
         if ensure_all

--- a/lib/OUQBase/src/operators.jl
+++ b/lib/OUQBase/src/operators.jl
@@ -1,7 +1,7 @@
-import Symbolics: Operator, value
-import SymbolicUtils: symtype, term
+import Symbolics: value
+import SymbolicUtils: term
 
-struct 𝔼_ <: Operator end
+struct 𝔼_ end
 
 const 𝔼 = 𝔼_() # To get same object
 
@@ -30,7 +30,7 @@ struct ℙ <: Operator
 end
 =#
 
-struct ℙ_ <: Operator end
+struct ℙ_ end
 
 const ℙ = ℙ_() # To get same object
 

--- a/lib/OUQBase/src/operators.jl
+++ b/lib/OUQBase/src/operators.jl
@@ -1,14 +1,20 @@
 import Symbolics: Operator, value
-import SymbolicUtils: Term, symtype
+import SymbolicUtils: symtype, term
 
 struct 𝔼_ <: Operator end
 
 const 𝔼 = 𝔼_() # To get same object
 
-(::𝔼_)(x) = Term{symtype(x)}(𝔼, Any[x])
+# `term` (rather than constructing `Term{T}` directly) picks the SymVariant
+# type parameter itself and infers the symbolic type via `promote_symtype`.
+(::𝔼_)(x) = term(𝔼, x)
 (::𝔼_)(x::Num) = Num(𝔼(value(x)))
 
 SymbolicUtils.promote_symtype(::𝔼_, x) = x
+# Disambiguates against SymbolicUtils's generic `promote_symtype(::Operator,
+# ::Type{T}) where T`, which is equally specific to the untyped method above
+# when called with a `Type` argument (e.g. `symtype(x) === Real`).
+SymbolicUtils.promote_symtype(::𝔼_, ::Type{T}) where {T} = T
 Base.nameof(::𝔼_) = :𝔼
 SymbolicUtils.isbinop(::𝔼_) = false
 
@@ -28,10 +34,11 @@ struct ℙ_ <: Operator end
 
 const ℙ = ℙ_() # To get same object
 
-(::ℙ_)(x) = Term{symtype(x)}(ℙ, Any[x])
+(::ℙ_)(x) = term(ℙ, x)
 (::ℙ_)(x::Num) = Num(ℙ(value(x)))
 
 SymbolicUtils.promote_symtype(::ℙ_, x) = x
+SymbolicUtils.promote_symtype(::ℙ_, ::Type{T}) where {T} = T
 Base.nameof(::ℙ_) = :ℙ
 SymbolicUtils.isbinop(::ℙ_) = false
 

--- a/lib/OUQBase/src/reduction_transformations/canonical_moments.jl
+++ b/lib/OUQBase/src/reduction_transformations/canonical_moments.jl
@@ -6,7 +6,7 @@ function get_raw_moment_order(equation::Union{Equation, Inequality}, random_var:
     if Symbolics.wrap(_eq.lhs) === random_var
         return 1
     end
-    order = _eq.lhs
+    order = Symbolics.value(_eq.lhs)
     if !isa(order, Int64)
         error(
             "Equation $(equation) is not a raw moment equation of the form: 𝔼(Q^n) ~ <Float64> where n is an Integer",
@@ -21,8 +21,9 @@ function build_raw_moment_sequence(
     )
     num_group_cons = length(constraints)
     raw_moment_sequence = fill(NaN, num_group_cons)
-    for (i, constraint) in enumerate(constraints)
-        raw_moment_sequence[get_raw_moment_order(constraint, random_var)] = constraint.rhs
+    for constraint in constraints
+        moment_order = get_raw_moment_order(constraint, random_var)
+        raw_moment_sequence[moment_order] = Symbolics.value(constraint.rhs)
     end
     !any(isnan, raw_moment_sequence) || error("Raw moments have holes")
     lb, ub = getbounds(random_var)
@@ -39,6 +40,17 @@ function create_raw_moments_map(admissible_set::AbstractAdmissibleSet)
         raw_moments_map[k] = build_raw_moment_sequence(random_var, v)
     end
     return raw_moments_map
+end
+
+function _evaluate_condition(condition::Inequality, substitutions)
+    lhs = Symbolics.value(substitute(condition.lhs, substitutions; fold = Val(true)))
+    rhs = Symbolics.value(substitute(condition.rhs, substitutions; fold = Val(true)))
+    if condition.relational_op == _LEQ_RELATIONAL_OPERATOR
+        return lhs <= rhs
+    elseif condition.relational_op == _GEQ_RELATIONAL_OPERATOR
+        return lhs >= rhs
+    end
+    throw(ArgumentError("Unsupported inequality: $condition"))
 end
 
 # This creates the optimization decision variables for the canonical moment problem.
@@ -250,7 +262,7 @@ function construct_optimization_problem(
     if isa(ouq_sys.objective, ProbabilityObjective)
         # TODO: Dispatch on Probability Function approximation here.
         ouq_obj_f =
-            (rand_var_vec) -> Symbolics.evaluate(
+            (rand_var_vec) -> _evaluate_condition(
             condition,
             Dict(constituent_random_variables .=> rand_var_vec),
         )

--- a/lib/OUQBase/src/reduction_transformations/winkler_extremal_measures.jl
+++ b/lib/OUQBase/src/reduction_transformations/winkler_extremal_measures.jl
@@ -5,9 +5,9 @@ function convert_inequality_to_jump_leq_lhs(
         complement = false,
         tol = 1.0e-10,
     )
-    if ineq.relational_op == Symbolics.leq
+    if ineq.relational_op == _LEQ_RELATIONAL_OPERATOR
         jump_leq_lhs = complement ? ineq.rhs - ineq.lhs + tol : ineq.lhs - ineq.rhs
-    elseif ineq.relational_op == Symbolics.geq
+    elseif ineq.relational_op == _GEQ_RELATIONAL_OPERATOR
         jump_leq_lhs = complement ? ineq.lhs - ineq.rhs - tol : ineq.rhs - ineq.lhs
     else
         error("Unsupported inequality: $ineq")
@@ -386,10 +386,9 @@ function construct_optimization_problem(
         ensure_all = true,
     )
 
-    ## In the exact case, we are using the Symbolic.evaluate function
     # TODO: Dispatch on Probability Function approximation here.
     reduced_objective = expectation(
-        (single_support) -> Symbolics.evaluate(
+        (single_support) -> _evaluate_condition(
             condition,
             Dict(constituent_random_variables .=> single_support),
         ),

--- a/lib/OUQBase/test/Core/FloodProblem/Q_only.jl
+++ b/lib/OUQBase/test/Core/FloodProblem/Q_only.jl
@@ -1,5 +1,6 @@
 using Symbolics, ModelingToolkit
 using OUQBase
+using CanonicalMoments: moments
 using Test
 using OptimizationBBO
 
@@ -7,6 +8,10 @@ using OptimizationBBO
 rand_vars = @random_variables begin
     Independent(Q, bounds = (160.0, 3580.0))
 end
+@test OUQBase._evaluate_condition(Q ≲ 160.0, Dict(Q => 160.0))
+@test OUQBase._evaluate_condition(Q ≳ 160.0, Dict(Q => 160.0))
+@test !OUQBase._evaluate_condition(Q ≲ 160.0, Dict(Q => 161.0))
+@test !OUQBase._evaluate_condition(Q ≳ 160.0, Dict(Q => 159.0))
 
 constraints = [𝔼(Q) ~ 1320.42]
 
@@ -41,6 +46,17 @@ ouq_sys_expectation_canonical_moments = OUQSystem(;
     reduction_alg = StengerCanonicalMoments(),
     parameters = pars,
 )
+@test Symbolics.value.(
+    moments(
+        only(
+            values(
+                raw_moments_map(
+                    ouq_sys_expectation_canonical_moments,
+                )
+            )
+        )
+    )
+) == [1320.42]
 ouq_sys_expectation_canonical_moments_analytic = OUQSystem(;
     objective = objective_expectation,
     admissible_set,

--- a/lib/OUQBase/test/qa/qa.jl
+++ b/lib/OUQBase/test/qa/qa.jl
@@ -18,13 +18,12 @@ run_qa(
         # Non-public qualified accesses into upstream packages; still non-public in the
         # resolved upstream majors:
         #   :BasicSymbolic/:isbinop/:promote_symtype - SymbolicUtils
-        #   :evaluate/:geq/:leq                      - Symbolics
         #   :getdefault                              - ModelingToolkit
         #   :NoAD/:NullParameters                    - SciMLBase
         all_qualified_accesses_are_public = (;
             ignore = (
-                :BasicSymbolic, :NoAD, :NullParameters, :evaluate, :geq, :getdefault,
-                :isbinop, :leq, :promote_symtype,
+                :BasicSymbolic, :NoAD, :NullParameters, :getdefault, :isbinop,
+                :promote_symtype,
             ),
         ),
     ),

--- a/src/OptimalUncertaintyQuantification.jl
+++ b/src/OptimalUncertaintyQuantification.jl
@@ -3,6 +3,11 @@ module OptimalUncertaintyQuantification
 using Reexport: @reexport
 @reexport using OUQBase
 
+# `@random_variables` expands to code that references `Symbolics.@variables`
+# in the caller's scope (via `esc`), so `Symbolics` must be bound here for the
+# precompile workload below to expand successfully.
+using Symbolics: Symbolics
+
 using PrecompileTools: @compile_workload, @setup_workload
 
 @setup_workload begin
@@ -11,7 +16,7 @@ using PrecompileTools: @compile_workload, @setup_workload
             Independent(Q, bounds = (0.0, 1.0))
         end
         admissible_set = AdmissibleSet(random_vars, [𝔼(Q) ~ 0.5])
-        OUQSystem(
+        OUQSystem(;
             objective = 𝔼(Q),
             admissible_set,
             reduction_alg = WinklerExtremalMeasures(),


### PR DESCRIPTION
> [!IMPORTANT]
> Please ignore this draft until it has been reviewed by @ChrisRackauckas.

## What changed and why

This is stacked on the head of https://github.com/SciML/OptimalUncertaintyQuantification.jl/pull/48 (`e09e7f03cb487178af23237b66273102c94605d3`). It fixes the OUQBase failures that remain after that PR: Symbolics 7 wraps numeric equation sides and rewritten exponents in `BasicSymbolic`, while OUQBase's raw-moment builder stores concrete numbers; OUQBase also relied on several Symbolics/SymbolicUtils implementation details that are not public API.

The first commit unwraps numeric constants with public `Symbolics.value`, evaluates inequalities with public `SymbolicUtils.substitute` plus documented `Inequality` fields, and adds moment and inclusive-boundary regressions. The second commit models the OUQ operator functors locally, identifies random variables from the admissible-set map, and removes the remaining nonpublic `Operator`, `default_is_atomic`, `evaluate`, `geq`, and `leq` accesses without adding QA ignores.

Both fixes are in one stacked PR because either commit alone leaves OUQBase CI red: Core/downgrade require the constant and condition handling, while QA requires the public-interface cleanup.

## Root cause and history

The adjacent scheduled-run boundary is:

- last green sublibrary run: `01c015fef4176e370c21ed0d0204b91ee4923b47`
- first red run: `939aeff699d4b727d4dd04d4471113f3bc6063fa` (`Drop stale [compat] majors older than one year`)

That compat change first made the graph unresolvable; https://github.com/SciML/OptimalUncertaintyQuantification.jl/pull/49 repaired resolution. Once resolved, https://github.com/SciML/OptimalUncertaintyQuantification.jl/pull/48 exposed the latent OUQBase assumptions under Symbolics 7.37–7.39: numeric constants are symbolic wrappers, and several names OUQBase used are not declared public by their owner modules.

The replacement dependencies were checked at their owners: `Symbolics.value`, `Symbolics.wrap`, `Symbolics.Inequality`, `Symbolics.≲`, and `Symbolics.≳` are public/documented; `SymbolicUtils.term` and `SymbolicUtils.substitute` are public/exported, and `substitute(...; fold=Val(true))` is documented. `SymbolicUtils.Operator`, `SymbolicUtils.default_is_atomic`, `Symbolics.evaluate`, `Symbolics.geq`, and `Symbolics.leq` are not public and are no longer used.

## Failing before

On the unmodified PR 48 head with Julia 1.12.7, the focused canonical-moment constructor printed the wrapped RHS type and failed in the Float64 assignment:

```text
rhs_type=SymbolicUtils.BasicSymbolicImpl.var"typeof(BasicSymbolicImpl)"{SymReal}
ERROR: Unreachable reached.
...
convert(::Type{Float64}, ::SymbolicUtils.BasicSymbolicImpl.var"typeof(BasicSymbolicImpl)"{SymReal})
...
build_raw_moment_sequence ... canonical_moments.jl:25
```

The hosted PR 48 composition independently failed OUQBase Core, QA, and downgrade:

- Core current: https://github.com/SciML/OptimalUncertaintyQuantification.jl/actions/runs/33170683697/job/98853663880
- QA: https://github.com/SciML/OptimalUncertaintyQuantification.jl/actions/runs/33170683697/job/98853663836
- downgrade: https://github.com/SciML/OptimalUncertaintyQuantification.jl/actions/runs/33170683468/job/98853378600

## Passing after

Focused discriminator on the patched code:

```text
FOCUSED_REPRO_PASS rhs_type=SymbolicUtils.BasicSymbolicImpl.var"typeof(BasicSymbolicImpl)"{SymReal} storage_type=Vector{Float64}
BOUNDARY_CONDITION_PASS
```

Current Julia Core:

```console
$ GROUP=OUQBase JULIA_NUM_THREADS=2 julia +1.12 --project=. -e 'using Pkg; Pkg.test()'
Test Summary:          | Pass  Total      Time
Flood Problem (Q only) |    5      5  13m25.4s
Test Summary:                               | Pass  Total  Time
Flood Problem (canonical moments objective) |    6      6  3.5s
Testing OUQBase tests passed
Testing OptimalUncertaintyQuantification tests passed
```

Current Julia QA:

```console
$ GROUP=OUQBase_QA JULIA_NUM_THREADS=2 julia +1.12 --project=. -e 'using Pkg; Pkg.test()'
Test Summary:     | Pass  Total     Time
Quality Assurance |   18     18  4m02.7s
Testing OUQBase tests passed
Testing OptimalUncertaintyQuantification tests passed
```

Hosted CI completed with 22 successful checks, one empty-matrix skip, and one failure. All
OUQBase Core checks on current, LTS, and prerelease Julia, OUQBase QA, and OUQBase downgrade
passed. The only failure is the root umbrella QA job, whose five implicit facade imports,
17 undocumented bindings, 23 unapproved reexports, and 18-pass/2-fail/1-error summary exactly
match the failure on the stacked base PR:

- passing OUQBase QA: https://github.com/SciML/OptimalUncertaintyQuantification.jl/actions/runs/33482929985/job/99776517452
- current root QA: https://github.com/SciML/OptimalUncertaintyQuantification.jl/actions/runs/33482929946/job/99776514898
- matching stacked-base root QA: https://github.com/SciML/OptimalUncertaintyQuantification.jl/actions/runs/33170683707/job/98853669231

Exact sublibrary downgrade workflow, run with Julia 1.10.12 in a workspace-local isolated depot and the reusable workflow's effective stdlib/in-tree skip set:

```console
$ julia +lts --startup-file=no julia-downgrade-compat-v2/downgrade.jl "$EFFECTIVE_SKIP" lib/OUQBase alldeps 1.10 ''
[ Info: Successfully resolved minimal versions for lib/OUQBase (with extras)
⌥ [d1185830] SymbolicUtils v4.38.0
⌃ [0c5d862f] Symbolics v7.37.0
$ OPTIMALUNCERTAINTYQUANTIFICATION_TEST_GROUP=Core JULIA_NUM_THREADS=2 julia +lts --startup-file=no --project=lib/OUQBase -e 'using Pkg; Pkg.test(allow_reresolve=false)'
Test Summary:          | Pass  Total   Time
Flood Problem (Q only) |    5      5  31.9s
Test Summary:                               | Pass  Total  Time
Flood Problem (canonical moments objective) |    6      6  1.9s
Testing OUQBase tests passed
```

Mechanical checks:

```console
$ julia +1.12 --project="$HOME/.julia/environments/@runic117" -m Runic --check --diff <all changed .jl files>
$ typos <all changed .jl files>
$ git diff --check
RUNIC_EXIT:0 TYPOS_EXIT:0 DIFF_CHECK_EXIT:0
```

## Not verified / scope

- No docs build was run because this PR adds no public name and changes no public docstring or rendered documentation; its new helpers/constants are private.
- The unrelated root umbrella QA facade/reexport failures visible on PR 48 are outside this OUQBase-only follow-up and are not hidden or allow-listed here.
- The root umbrella facade failure will be handled separately so this OUQBase repair remains focused.

## Links

- Stacked base PR: https://github.com/SciML/OptimalUncertaintyQuantification.jl/pull/48
- Resolver repair PR: https://github.com/SciML/OptimalUncertaintyQuantification.jl/pull/49
- Last adjacent green run: https://github.com/SciML/OptimalUncertaintyQuantification.jl/actions/runs/32953550950
- First adjacent red run: https://github.com/SciML/OptimalUncertaintyQuantification.jl/actions/runs/32967899726
- PR 48 OUQBase Core failure: https://github.com/SciML/OptimalUncertaintyQuantification.jl/actions/runs/33170683697/job/98853663880
- PR 48 OUQBase QA failure: https://github.com/SciML/OptimalUncertaintyQuantification.jl/actions/runs/33170683697/job/98853663836
- PR 48 OUQBase downgrade failure: https://github.com/SciML/OptimalUncertaintyQuantification.jl/actions/runs/33170683468/job/98853378600
- PR 50 passing OUQBase QA: https://github.com/SciML/OptimalUncertaintyQuantification.jl/actions/runs/33482929985/job/99776517452
- PR 50 known root facade QA failure: https://github.com/SciML/OptimalUncertaintyQuantification.jl/actions/runs/33482929946/job/99776514898
- Matching PR 48 root facade QA failure: https://github.com/SciML/OptimalUncertaintyQuantification.jl/actions/runs/33170683707/job/98853669231

🤖 Generated with Codex CLI (model: gpt-5.6-sol; session: local session ID 01a0598f-11b9-72d1-91d9-b2fbb186557d).
